### PR TITLE
Uniform Radio Button Style

### DIFF
--- a/src/assets/styles/utilities/index.css
+++ b/src/assets/styles/utilities/index.css
@@ -1,2 +1,3 @@
 @import 'buttons.css';
 @import 'links.css';
+@import 'radiobuttons.css';

--- a/src/assets/styles/utilities/radiobuttons.css
+++ b/src/assets/styles/utilities/radiobuttons.css
@@ -1,0 +1,11 @@
+.radio {
+    @apply text-blue-700;
+}
+
+.radio:focus {
+    @apply shadow-none;
+}
+
+.radio:hover {
+    @apply bg-blue-400;
+}

--- a/src/views/admin/CreateAccountForm.vue
+++ b/src/views/admin/CreateAccountForm.vue
@@ -23,7 +23,7 @@
                             <div class="flex">
                                 <div class="mr-4 mb-3" v-for="role in roles" :key="role">
                                     <label class="flex items-center" >
-                                        <input type="radio" class="form-radio focus:shadow-none text-blue-700 hover:bg-blue-400" name="role" :value="role" v-model="account.role">
+                                        <input type="radio" class="form-radio radio" name="role" :value="role" v-model="account.role">
                                         <span class="ml-2 text-gray-700 text-md font-medium">{{ role }}</span>
                                     </label>
                                 </div>

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -24,7 +24,7 @@
                             <div class="flex">
                                 <div class="mr-4" v-for="courseType in courseTypes" :key="courseType">
                                     <label class="flex items-center">
-                                        <input type="radio" class="form-radio focus:shadow-none text-blue-700 hover:bg-blue-400" name="type" :value="courseType"
+                                        <input type="radio" class="form-radio radio" name="type" :value="courseType"
                                                v-model="course.courseType">
                                         <span class="ml-2 text-gray-700 text-md font-medium">{{ courseType }}</span>
                                     </label>


### PR DESCRIPTION
Add uniform style for radio buttons (blue by default). However, I was unable to also `@apply radio-form` to the class as this is loaded via a tailwindcss plugin and not part of the base utilities. This means we still have to use these 2 classes for a styled radio button `radio-form radio`. Maybe it is possible to include the plugin's classes in the custom "utilities" styles, but I was unable to do so easily.  