### PR TITLE
Feature/refactor birthdatepicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-web",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/BirthDatePicker.vue
+++ b/src/components/BirthDatePicker.vue
@@ -1,0 +1,83 @@
+<template>
+    <div class="flex flex-row ">
+        <div class="w-full px-2 flex flex-col">
+            <label class="text-gray-700 text-sm">Day</label>
+            <select class="w-4/5 mr-1 my-2 py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
+                @change="updateDay($event.target.value)"
+                >
+                <option selected disabled> Select a Day </option>
+                <option v-for="day in 31" :key="day">{{ day }}</option>
+            </select>
+        </div>
+        <div class="w-full px-2 flex flex-col">
+            <label class="text-gray-700 text-sm">Month  </label>
+            <select class="w-4/5 mr-1 my-2 py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
+                @change="updateMonth($event.target.value)"
+                >
+                <option selected disabled> Select a Month </option>
+                <option v-for="month in months" :key="month">{{ month }}</option>
+            </select>
+        </div>
+        <div class="w-full pl-2 flex flex-col">
+            <label class="text-gray-700 text-sm">Year</label>
+            <select class="w-4/5 mr-1 my-2 py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
+                @change="updateYear($event.target.value)"
+                >
+                <option selected disabled> Select a Year </option>
+                <option v-for="year in selectableYears" :key="year">{{ year }}</option>
+            </select>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+    import { Month } from "@/entities/Month"
+    export default {
+        name: "BirthDatePicker",
+        props: {
+            year: {
+                type: String,
+                required: true,
+            },
+            month: {
+                type: String,
+                required: true,
+            },
+            day: {
+                type: String,
+                required: true,
+            },
+        },
+
+
+        setup() {
+            let months = Month;
+            let currentYear = new Date().getFullYear();
+            let selectableYears = [];
+
+            for (let index = currentYear; index >= currentYear-80; index--) {
+                selectableYears.push(index);
+            }
+
+            function updateDay(day:string) {
+               
+            }
+
+            function updateMonth(month:string) {
+
+            }
+
+            function updateYear(year:string) {
+
+            }
+
+            return {
+                months,
+                selectableYears,
+                updateDay,
+                updateMonth,
+                updateYear
+            }
+        }
+    }
+</script>

--- a/src/components/BirthDatePicker.vue
+++ b/src/components/BirthDatePicker.vue
@@ -4,7 +4,7 @@
             <label class="text-gray-700 text-sm">Day</label>
             <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
                 @change="updateDay($event.target.value)"
-                v-model="myday"
+                v-model="shownDay"
                 >
                 <option disabled :value="''"> Select a Day </option>
                 <option v-for="day in 31" :key="day">{{ day }}</option>
@@ -14,7 +14,7 @@
             <label class="text-gray-700 text-sm">Month  </label>
             <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
                 @change="updateMonth($event.target.value)"
-                v-model="mymonth"
+                v-model="shownMonth"
                 >
                 <option disabled :value="''"> Select a Month </option>
                 <option v-for="month in months" :key="month">{{ month }}</option>
@@ -24,7 +24,7 @@
             <label class="text-gray-700 text-sm">Year</label>
             <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
                 @change="updateYear($event.target.value)"
-                v-model="myyear"
+                v-model="shownYear"
                 >
                 <option disabled :value="''"> Select a Year </option>
                 <option v-for="year in selectableYears" :key="year">{{ year }}</option>
@@ -55,13 +55,13 @@
 
         setup(props:any, { emit } ) {
             let months = Month;
+            
+            let shownDay:string = ref(props.day).value;
+            let shownMonth:string = ref(props.month).value == "" ? "" : Object.values(Month)[parseInt(ref(props.month).value)-1];
+            let shownYear:string = ref(props.year).value;
+
             let currentYear = new Date().getFullYear();
             let selectableYears = [];
-            
-            let myday:string = ref(props.day).value;
-            let mymonth:string = ref(props.month).value == "" ? "" : Object.values(Month)[parseInt(ref(props.month).value)-1];
-            let myyear:string = ref(props.year).value;
-
             for (let index = currentYear; index >= currentYear-80; index--) {
                 selectableYears.push(index);
             }
@@ -83,9 +83,9 @@
             }
 
             return {
-                myday,
-                mymonth,
-                myyear,
+                shownDay,
+                shownMonth,
+                shownYear,
                 months,
                 selectableYears,
                 updateDay,

--- a/src/components/BirthDatePicker.vue
+++ b/src/components/BirthDatePicker.vue
@@ -4,8 +4,9 @@
             <label class="text-gray-700 text-sm">Day</label>
             <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
                 @change="updateDay($event.target.value)"
+                v-model="myday"
                 >
-                <option selected disabled> Select a Day </option>
+                <option disabled :value="''"> Select a Day </option>
                 <option v-for="day in 31" :key="day">{{ day }}</option>
             </select>
         </div>
@@ -13,8 +14,9 @@
             <label class="text-gray-700 text-sm">Month  </label>
             <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
                 @change="updateMonth($event.target.value)"
+                v-model="mymonth"
                 >
-                <option selected disabled> Select a Month </option>
+                <option disabled :value="''"> Select a Month </option>
                 <option v-for="month in months" :key="month">{{ month }}</option>
             </select>
         </div>
@@ -22,8 +24,9 @@
             <label class="text-gray-700 text-sm">Year</label>
             <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
                 @change="updateYear($event.target.value)"
+                v-model="myyear"
                 >
-                <option selected disabled> Select a Year </option>
+                <option disabled :value="''"> Select a Year </option>
                 <option v-for="year in selectableYears" :key="year">{{ year }}</option>
             </select>
         </div>
@@ -32,6 +35,7 @@
 
 <script lang="ts">
     import { Month } from "@/entities/Month"
+    import { ref } from "vue"
     export default {
         name: "BirthDatePicker",
         props: {
@@ -49,11 +53,14 @@
             },
         },
 
-
         setup(props:any, { emit } ) {
             let months = Month;
             let currentYear = new Date().getFullYear();
             let selectableYears = [];
+            
+            let myday:string = ref(props.day).value;
+            let mymonth:string = ref(props.month).value == "" ? "" : Object.values(Month)[parseInt(ref(props.month).value)-1];
+            let myyear:string = ref(props.year).value;
 
             for (let index = currentYear; index >= currentYear-80; index--) {
                 selectableYears.push(index);
@@ -76,6 +83,9 @@
             }
 
             return {
+                myday,
+                mymonth,
+                myyear,
                 months,
                 selectableYears,
                 updateDay,

--- a/src/components/BirthDatePicker.vue
+++ b/src/components/BirthDatePicker.vue
@@ -2,7 +2,7 @@
     <div class="flex flex-row ">
         <div class="mr-2 w-full flex flex-col">
             <label class="text-gray-700 text-sm">Day</label>
-            <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
+            <select class="form-select input-select" 
                 @change="updateDay($event.target.value)"
                 v-model="shownDay"
                 >
@@ -12,7 +12,7 @@
         </div>
         <div class="mx-2 w-full flex flex-col">
             <label class="text-gray-700 text-sm">Month  </label>
-            <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
+            <select class="form-select input-select" 
                 @change="updateMonth($event.target.value)"
                 v-model="shownMonth"
                 >
@@ -22,7 +22,7 @@
         </div>
         <div class="ml-2 w-full flex flex-col">
             <label class="text-gray-700 text-sm">Year</label>
-            <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
+            <select class="form-select input-select" 
                 @change="updateYear($event.target.value)"
                 v-model="shownYear"
                 >

--- a/src/components/BirthDatePicker.vue
+++ b/src/components/BirthDatePicker.vue
@@ -60,15 +60,19 @@
             }
 
             function updateDay(day:string) {
-               
+               if( parseInt(day) < 10 ) {
+                   day = "0" + day;
+               }
+               emit("update:day",day);
             }
 
             function updateMonth(month:string) {
-
+                let monthIndex = Object.values(months).indexOf(month as Month) + 1;
+                emit("update:month", monthIndex < 10 ? "0" + monthIndex : monthIndex.toString());
             }
 
             function updateYear(year:string) {
-
+                emit("update:year", year.toString());
             }
 
             return {

--- a/src/components/BirthDatePicker.vue
+++ b/src/components/BirthDatePicker.vue
@@ -56,7 +56,7 @@
         setup(props:any, { emit } ) {
             let months = Month;
             
-            let shownDay:string = ref(props.day).value;
+            let shownDay:string = parseInt(ref(props.day).value).toString();
             let shownMonth:string = ref(props.month).value == "" ? "" : Object.values(Month)[parseInt(ref(props.month).value)-1];
             let shownYear:string = ref(props.year).value;
 

--- a/src/components/BirthDatePicker.vue
+++ b/src/components/BirthDatePicker.vue
@@ -56,7 +56,7 @@
         setup(props:any, { emit } ) {
             let months = Month;
             
-            let shownDay:string = parseInt(ref(props.day).value).toString();
+            let shownDay:string = ref(props.day).value == "" ? "" : parseInt(ref(props.day).value).toString();
             let shownMonth:string = ref(props.month).value == "" ? "" : Object.values(Month)[parseInt(ref(props.month).value)-1];
             let shownYear:string = ref(props.year).value;
 

--- a/src/components/BirthDatePicker.vue
+++ b/src/components/BirthDatePicker.vue
@@ -1,26 +1,26 @@
 <template>
     <div class="flex flex-row ">
-        <div class="w-full px-2 flex flex-col">
+        <div class="mr-2 w-full flex flex-col">
             <label class="text-gray-700 text-sm">Day</label>
-            <select class="w-4/5 mr-1 my-2 py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
+            <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
                 @change="updateDay($event.target.value)"
                 >
                 <option selected disabled> Select a Day </option>
                 <option v-for="day in 31" :key="day">{{ day }}</option>
             </select>
         </div>
-        <div class="w-full px-2 flex flex-col">
+        <div class="mx-2 w-full flex flex-col">
             <label class="text-gray-700 text-sm">Month  </label>
-            <select class="w-4/5 mr-1 my-2 py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
+            <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
                 @change="updateMonth($event.target.value)"
                 >
                 <option selected disabled> Select a Month </option>
                 <option v-for="month in months" :key="month">{{ month }}</option>
             </select>
         </div>
-        <div class="w-full pl-2 flex flex-col">
+        <div class="ml-2 w-full flex flex-col">
             <label class="text-gray-700 text-sm">Year</label>
-            <select class="w-4/5 mr-1 my-2 py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
+            <select class="py-3 rounded-lg border-gray-400 text-gray-600 form-select" 
                 @change="updateYear($event.target.value)"
                 >
                 <option selected disabled> Select a Year </option>
@@ -50,7 +50,7 @@
         },
 
 
-        setup() {
+        setup(props:any, { emit } ) {
             let months = Month;
             let currentYear = new Date().getFullYear();
             let selectableYears = [];

--- a/src/components/MultiSelect.vue
+++ b/src/components/MultiSelect.vue
@@ -1,7 +1,8 @@
 <template>
     <div>
         <div class="w-full flex flex-row items-center" v-for="index in output.length" :key="index">
-            <select class="w-4/5 mr-1 my-2 input-select form-select"
+            <select class="w-4/5 mr-1 input-select form-select"  
+                :class="{'mb-2' : index !== output.length}"
                 v-model="output[index-1]"
                 @change="addValue($event.target.value,index-1)"
             >
@@ -12,10 +13,11 @@
 
                 <option v-for="field in unchosenValues" :key="field">{{ field }}</option>
             </select>
-            <div class="w-1/6 items-center justify-center">
+            <div class="w-1/6 items-center justify-center" 
+                :class="{'mb-2' : index !== output.length}">
                 <button v-if="output[index-1] != ''" @click="removeValue(index-1)" 
                 title="Remove Selected Field Of Study"
-                class="w-1/2 m-1 btn-icon-red"> 
+                class="w-1/2 btn-icon-red"> 
                     <i class="inline far fa-trash-alt text-lg"></i>
                 </button>
             </div>

--- a/src/entities/Month.ts
+++ b/src/entities/Month.ts
@@ -1,0 +1,14 @@
+export enum Month {
+    JANUARY = "January",
+    FEBRUARY = "February",
+    MARCH = "March",
+    APRIL = "April",
+    MAY = "May",
+    JUNE = "June",
+    JULY = "July",
+    AUGUST = "August",
+    SEPTEMBER = "September",
+    OCTOBER = "October",
+    NOVEMBER = "November",
+    DECEMBER = "December"
+}

--- a/src/views/admin/EditCreateAccountForm.vue
+++ b/src/views/admin/EditCreateAccountForm.vue
@@ -109,32 +109,7 @@
                                 Birthdate
                             </label>
                             <p v-if="hasError('birthDate')" class="text-red-600 ml-1 mt-1">{{ showError('birthDate') }}</p>
-                            <div class="flex flex-row ">
-                                <div class="w-full pr-2 flex-col">
-                                    <label class="text-gray-700 text-sm">Day</label>
-                                    <input type="number" id="day" name="day"
-                                        class="w-full border-2 border-gray-400 rounded-lg py-3 text-gray-600 form-input"
-                                        placeholder="DD"
-										v-model="account.birthDate.day"
-                                        >
-                                </div> 
-								<div class="w-full px-2 flex-col">
-                                    <label class="text-gray-700 text-sm">Month</label>
-                                    <input type="number" id="month" name="month"
-                                        class="w-full border-2 border-gray-400 rounded-lg py-3 text-gray-600 form-input"
-                                        placeholder="MM"
-										v-model="account.birthDate.month"
-                                        >
-                                </div>
-								<div class="w-full pl-2 flex-col">
-                                    <label class="text-gray-700 text-sm">Year</label>
-                                    <input type="number" id="year" name="year"
-                                        class="w-full border-2 border-gray-400 rounded-lg py-3 text-gray-600 form-input"
-                                        placeholder="YYYY"
-										v-model="account.birthDate.year"
-                                        >
-                                </div>
-                            </div>
+                            <birth-date-picker v-model:year="account.birthDate.year" v-model:month="account.birthDate.month" v-model:day="account.birthDate.day"/>
                         </div>
                         <div class="mb-4 flex flex-col">
                                 <label class="text-gray-700 text-md font-medium mb-3">
@@ -348,12 +323,14 @@ import useErrorHandler from '@/use/ErrorHandler';
 import ValidationResponseHandler from '../../use/ValidationResponseHandler';
 import GenericResponseHandler from "@/use/GenericResponseHandler"
 import MultiSelect from "@/components/MultiSelect.vue"
+import BirthDatePicker from "@/components/BirthDatePicker.vue"
 
 export default {
     name: "AdminCreateAccountForm",
     components: {
         DeleteAccountModal,
-        MultiSelect
+        MultiSelect,
+        BirthDatePicker
     },
     props: {
         editMode: {

--- a/src/views/admin/EditCreateAccountForm.vue
+++ b/src/views/admin/EditCreateAccountForm.vue
@@ -394,9 +394,6 @@ export default {
             if (response.statusCode !== 200) {
                 alert("User not found")
             } else {
-                //TODO Remove next line when lagom finally manage to send a birthdate
-                result.birthDate = "1996-12-11";
-
                 account.user  = result;
                 initialAccount.user = JSON.parse(JSON.stringify(account.user)) ;
                 let dates = result.birthDate.split("-");

--- a/src/views/admin/EditCreateAccountForm.vue
+++ b/src/views/admin/EditCreateAccountForm.vue
@@ -569,6 +569,7 @@ export default {
 
         function updateAccount() {
             const userManagement: UserManagement = new UserManagement();
+            account.user.birthDate = account.birthDate.year + "-" + account.birthDate.month + "-" + account.birthDate.day;
             var adaptedUser: Student | Lecturer | Admin = assembleAccount();
             userManagement.updateUser(adaptedUser).then( (response) => {
                 if(response) {

--- a/src/views/admin/EditCreateAccountForm.vue
+++ b/src/views/admin/EditCreateAccountForm.vue
@@ -108,8 +108,8 @@
                             <label class="text-gray-700 text-md font-medium mb-3">
                                 Birthdate
                             </label>
-                            <p v-if="hasError('birthDate')" class="text-red-600 ml-1 mt-1">{{ showError('birthDate') }}</p>
                             <birth-date-picker v-model:year="account.birthDate.year" v-model:month="account.birthDate.month" v-model:day="account.birthDate.day"/>
+                            <p v-if="hasError('birthDate')" class="text-red-600 ml-1 mt-1">{{ showError('birthDate') }}</p>
                         </div>
                         <div class="mb-4 flex flex-col">
                                 <label class="text-gray-700 text-md font-medium mb-3">


### PR DESCRIPTION
## Reasons for Change:
With the old birthdate input, we had the bug, that we transmit numbers < 3 without a trailing 0 to the API, which caused a validation error. This was cause by the input type "number". 
## In this PR:
The birthdate input is now extracted into an own component. Additionally, I changed the format of the inputs to a more human readable and user friendly one. They are now drop downs that include the options "1"-"31" for a day, "January"-"December" for a month (implemented as the enum "Month" in ```Entities/Month.ts```) and the last 80 years until the current date. Loading and setting dates with this new component is working via multiple v-models and emitting update events to the account form.

## Note:
- The order of the inputs from left to right is ```Day -> Month -> Year``` atm, localization is not included.
- The day selection is not bound to the months, s.t. a user does always have the possibility to select the days "1"-"31". Even though the backend should return an error, further restrictions in the frontend are possible, but not feasible for this sprint. 
