### PR TITLE
bugfix that wrong buttons would be shown on lecturer courses

### DIFF
--- a/src/components/LecturerCourse.vue
+++ b/src/components/LecturerCourse.vue
@@ -13,7 +13,7 @@
                 </div>
             </div>
 
-            <div class="flex">
+            <div class="flex mb-4">
                 <div class="flex flex-col lg:w-5/6 w-2/3">
                     <div class="mt-2 font-semibold text-2xl leading-tight truncate text-gray-900">{{ course.courseName }}</div>
                     <div class="mt-1 font-semibold text-sm text-gray-600">{{ course.lecturerId }}</div>
@@ -23,19 +23,7 @@
                 </div>
                 <div class="lg:w-1/6 w-1/3 lg:ml-8 ml-12">
                     <div class="mt-6 flex h-full items-center justify-center">
-                        <!-- v-if directive just for design purposes here -> replace with state of myCourses-->
-                        <button
-                            v-if="course.id === 123456789"
-                            class="bg-white text-red-600 border-2 shadow-md border-gray-300 py-2 px-8 rounded-lg focus:outline-none font-semibold"
-                        >
-                            Leave
-                        </button>
-                        <button v-else-if="course.currentParticipants < course.maxParticipants" class="w-48 btn btn-gray-primary">
-                            Join
-                        </button>
-                        <p v-else class="flex text-red-600 text-opacity-50 text-center py-2 px-8 rounded-lg font-semibold">
-                            Course is full
-                        </p>
+                        <button class="w-48 btn btn-gray-primary py-2" @click="editCourse()">Edit</button>
                     </div>
                 </div>
             </div>

--- a/src/components/StudentCourse.vue
+++ b/src/components/StudentCourse.vue
@@ -21,7 +21,7 @@
                         <read-more more-str="Show more" :text="course.courseDescription" less-str="Show less" :max-chars="180"></read-more>
                     </div>
                 </div>
-                <div class="lg:w-1/6 w-1/3 lg:ml-8 ml-12">
+                <div class="lg:w-1/6 w-1/3 lg:ml-8 ml-12 mb-4">
                     <div class="mt-6 flex h-full items-center justify-center">
                         <!-- v-if directive just for design purposes here -> replace with state of myCourses-->
                         <button
@@ -30,7 +30,7 @@
                         >
                             Leave
                         </button>
-                        <button v-else-if="course.currentParticipants < course.maxParticipants" class="w-48 btn btn-blue-primary">
+                        <button v-else-if="course.currentParticipants < course.maxParticipants" class="w-48 py-2 btn btn-blue-primary">
                             Join
                         </button>
                         <p v-else class="flex text-red-600 text-opacity-50 text-center py-2 px-8 rounded-lg font-semibold">


### PR DESCRIPTION
The lecturer course did display the same buttons as the student course. Bug was introduced by styling the courses with [commit 65f3d6e8df0b8fe06d9a0a2e7a8ac921ce5f7827](https://github.com/upb-uc4/ui-web/commit/65f3d6e8df0b8fe06d9a0a2e7a8ac921ce5f7827). 