### PR TITLE
Refactor CreateEditCourse

### DIFF
--- a/src/components/course/edit/BasicsSection.vue
+++ b/src/components/course/edit/BasicsSection.vue
@@ -11,16 +11,10 @@
                 <div class="mb-4 flex flex-col">
                     <label class="text-gray-700 text-md font-medium mb-3">Type</label>
                     <div class="flex">
-                        <div v-for="type in availableCourseTypes" :key="type" class="mr-4">
+                        <div v-for="availableType in availableCourseTypes" :key="availableType" class="mr-4">
                             <label class="flex items-center">
-                                <input
-                                    v-model="courseType"
-                                    type="radio"
-                                    class="form-radio radio"
-                                    name="type"
-                                    :value="type"
-                                />
-                                <span class="ml-2 text-gray-700 text-md font-medium">{{ type }}</span>
+                                <input v-model="courseType" type="radio" class="form-radio radio" :value="availableType" />
+                                <span class="ml-2 text-gray-700 text-md font-medium">{{ availableType }}</span>
                             </label>
                         </div>
                     </div>
@@ -29,12 +23,10 @@
                     </p>
                 </div>
                 <div class="mb-4 flex flex-col">
-                    <label for="name" class="text-gray-700 text-md font-medium mb-3">Name</label>
+                    <label class="text-gray-700 text-md font-medium mb-3">Name</label>
                     <input
-                        id="name"
                         v-model="courseName"
                         type="text"
-                        name="courseName"
                         class="w-full form-input input-text"
                         :class="{ error: errorBag.has('courseName') }"
                         placeholder="Course Name"
@@ -46,31 +38,29 @@
                 <div class="mb-4 flex flex-col">
                     <label class="text-gray-700 text-md font-medium mb-3">Language</label>
                     <select
-                        id="language"
                         v-model="courseLanguage"
-                        required
-                        name="language"
                         class="w-full form-select input-select"
+                        required
                         :class="{ error: errorBag.has('courseLanguage') }"
                     >
                         <option disabled :value="''">Select a Language</option>
-                        <option v-for="language in availableCourseLanguages" :key="language">{{ language }}</option>
+                        <option v-for="availableLanguage in availableCourseLanguages" :key="availableLanguage">{{
+                            availableLanguage
+                        }}</option>
                     </select>
                     <p v-if="errorBag.has('courseLanguage')" class="error-message">
                         {{ errorBag.get("courseLanguage") }}
                     </p>
                 </div>
                 <div class="mb-4 flex flex-col">
-                    <label for="description" class="text-gray-700 text-md font-medium mb-3">
+                    <label class="text-gray-700 text-md font-medium mb-3">
                         Description
                         <span class="text-gray-600 font-normal">
                             (Optional)
                         </span>
                     </label>
                     <textarea
-                        id="description"
                         v-model="courseDescription"
-                        name="description"
                         cols="30"
                         rows="10"
                         class="w-full form-textarea border-2 border-gray-400 rounded-lg text-gray-600"
@@ -87,22 +77,47 @@
 </template>
 
 <script lang="ts">
-    import ErrorBag from "../../../use/ErrorBag";
-    import {CourseType} from "@/entities/CourseType";
-    import {Language} from "@/entities/Language";
+    import ErrorBag from "@/use/ErrorBag";
+    import { CourseType } from "@/entities/CourseType";
+    import { Language } from "@/entities/Language";
+    import { useModelWrapper } from "@/use/ModelWrapper";
 
     export default {
         name: "BasicsSection",
         props: {
             errorBag: {
                 required: true,
-                type: ErrorBag
+                type: ErrorBag,
+            },
+            type: {
+                required: true,
+                type: String,
+            },
+            name: {
+                required: true,
+                type: String,
+            },
+            language: {
+                required: true,
+                type: String,
+            },
+            description: {
+                required: true,
+                type: String,
             },
         },
-        setup(props: any){
+        setup(props: any, { emit }: any) {
             const availableCourseLanguages = Object.values(Language).filter((e) => e != Language.NONE);
             const availableCourseTypes = Object.values(CourseType).filter((e) => e != CourseType.NONE);
-            return {availableCourseLanguages, availableCourseTypes};
-        }
-    }
+
+            return {
+                availableCourseLanguages,
+                availableCourseTypes,
+                courseType: useModelWrapper(props, emit, "type"),
+                courseName: useModelWrapper(props, emit, "name"),
+                courseLanguage: useModelWrapper(props, emit, "language"),
+                courseDescription: useModelWrapper(props, emit, "description"),
+            };
+        },
+    };
 </script>

--- a/src/components/course/edit/BasicsSection.vue
+++ b/src/components/course/edit/BasicsSection.vue
@@ -1,0 +1,108 @@
+<template>
+    <section class="border-t-2 py-8 border-gray-400">
+        <div class="lg:flex">
+            <div class="w-full lg:w-1/3 lg:block mr-12 flex flex-col mb-4">
+                <label class="block text-gray-700 text-lg font-medium mb-2">Basics</label>
+                <label class="block text-gray-600">
+                    This is some long detailed description which is part towards a better form.
+                </label>
+            </div>
+            <div class="w-full lg:w-2/3">
+                <div class="mb-4 flex flex-col">
+                    <label class="text-gray-700 text-md font-medium mb-3">Type</label>
+                    <div class="flex">
+                        <div v-for="type in availableCourseTypes" :key="type" class="mr-4">
+                            <label class="flex items-center">
+                                <input
+                                    v-model="courseType"
+                                    type="radio"
+                                    class="form-radio radio"
+                                    name="type"
+                                    :value="type"
+                                />
+                                <span class="ml-2 text-gray-700 text-md font-medium">{{ type }}</span>
+                            </label>
+                        </div>
+                    </div>
+                    <p v-if="errorBag.has('courseType')" class="error-message">
+                        {{ errorBag.get("courseType") }}
+                    </p>
+                </div>
+                <div class="mb-4 flex flex-col">
+                    <label for="name" class="text-gray-700 text-md font-medium mb-3">Name</label>
+                    <input
+                        id="name"
+                        v-model="courseName"
+                        type="text"
+                        name="courseName"
+                        class="w-full form-input input-text"
+                        :class="{ error: errorBag.has('courseName') }"
+                        placeholder="Course Name"
+                    />
+                    <p v-if="errorBag.has('courseName')" class="error-message">
+                        {{ errorBag.get("courseName") }}
+                    </p>
+                </div>
+                <div class="mb-4 flex flex-col">
+                    <label class="text-gray-700 text-md font-medium mb-3">Language</label>
+                    <select
+                        id="language"
+                        v-model="courseLanguage"
+                        required
+                        name="language"
+                        class="w-full form-select input-select"
+                        :class="{ error: errorBag.has('courseLanguage') }"
+                    >
+                        <option disabled :value="''">Select a Language</option>
+                        <option v-for="language in availableCourseLanguages" :key="language">{{ language }}</option>
+                    </select>
+                    <p v-if="errorBag.has('courseLanguage')" class="error-message">
+                        {{ errorBag.get("courseLanguage") }}
+                    </p>
+                </div>
+                <div class="mb-4 flex flex-col">
+                    <label for="description" class="text-gray-700 text-md font-medium mb-3">
+                        Description
+                        <span class="text-gray-600 font-normal">
+                            (Optional)
+                        </span>
+                    </label>
+                    <textarea
+                        id="description"
+                        v-model="courseDescription"
+                        name="description"
+                        cols="30"
+                        rows="10"
+                        class="w-full form-textarea border-2 border-gray-400 rounded-lg text-gray-600"
+                        :class="{ error: errorBag.has('courseDescription') }"
+                        placeholder="Add an optional description."
+                    />
+                    <p v-if="errorBag.has('courseDescription')" class="error-message">
+                        {{ errorBag.get("courseDescription") }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+<script lang="ts">
+    import ErrorBag from "../../../use/ErrorBag";
+    import {CourseType} from "@/entities/CourseType";
+    import {Language} from "@/entities/Language";
+
+    export default {
+        name: "BasicsSection",
+        props: {
+            errorBag: {
+                required: true,
+                type: ErrorBag
+            },
+        },
+        setup(props: any){
+            const availableCourseLanguages = Object.values(Language).filter((e) => e != Language.NONE);
+            const availableCourseTypes = Object.values(CourseType).filter((e) => e != CourseType.NONE);
+            return {availableCourseLanguages, availableCourseTypes};
+        }
+    }
+</script>

--- a/src/components/course/edit/RestrictionsSection.vue
+++ b/src/components/course/edit/RestrictionsSection.vue
@@ -1,0 +1,52 @@
+<template>
+    <section class="border-t-2 py-8 border-gray-400">
+        <div class="lg:flex">
+            <div class="w-full lg:w-1/3 lg:block mr-12 flex flex-col mb-4">
+                <label class="block text-gray-700 text-md font-medium mb-2">Restrictions</label>
+                <label class="block text-gray-600">
+                    This is some long detailed description which is part towards a better form.
+                </label>
+            </div>
+            <div class="w-full lg:w-2/3">
+                <div class="mb-4 flex flex-col">
+                    <label class="text-gray-700 text-md font-medium mb-3">Participation Limit</label>
+                    <input
+                        v-model="maxParticipants"
+                        type="number"
+                        min="0"
+                        max="999"
+                        class="w-full form-input input-text"
+                        :class="{ error: errorBag.has('maxParticipants') }"
+                    />
+                    <p v-if="errorBag.has('maxParticipants')" class="error-message">
+                        {{ errorBag.get("maxParticipants") }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+<script lang="ts">
+    import ErrorBag from "@/use/ErrorBag";
+    import { useModelWrapper } from "@/use/ModelWrapper";
+
+    export default {
+        name: "RestrictionsSection",
+        props: {
+            errorBag: {
+                required: true,
+                type: ErrorBag,
+            },
+            participantsLimit: {
+                required: true,
+                type: Number,
+            },
+        },
+        setup(props: any, { emit }: any) {
+            return {
+                maxParticipants: useModelWrapper(props, emit, "participantsLimit"),
+            };
+        },
+    };
+</script>

--- a/src/components/course/edit/TimeSection.vue
+++ b/src/components/course/edit/TimeSection.vue
@@ -1,0 +1,65 @@
+<template>
+    <section class="border-t-2 py-8 border-gray-400">
+        <div class="lg:flex">
+            <div class="w-full lg:w-1/3 lg:block mr-12 flex flex-col mb-4">
+                <label class="block text-gray-700 text-md font-medium mb-2">Time</label>
+                <label class="block text-gray-600">
+                    This section is disabled for now as there is no Vue3 datepicker plugin yet.
+                </label>
+            </div>
+            <div class="w-full lg:w-2/3 flex">
+                <div class="w-1/2 mb-4 mr-12 flex flex-col">
+                    <label class="text-gray-700 text-md font-medium mb-3">Start Date</label>
+                    <input
+                        v-model="startDate"
+                        type="text"
+                        readonly
+                        class="w-full form-input input-text"
+                        :class="{ error: errorBag.has('startDate') }"
+                    />
+                    <p v-if="errorBag.has('startDate')" class="error-message">{{ errorBag.get("startDate") }}</p>
+                </div>
+                <div class="w-1/2 mb-4 flex flex-col">
+                    <label class="text-gray-700 text-md font-medium mb-3">End Date</label>
+                    <input
+                        v-model="endDate"
+                        type="text"
+                        readonly
+                        class="w-full form-input input-text"
+                        :class="{ error: errorBag.has('endDate') }"
+                    />
+                    <p v-if="errorBag.has('endDate')" class="error-message">{{ errorBag.get("endDate") }}</p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+<script lang="ts">
+    import ErrorBag from "@/use/ErrorBag";
+    import { useModelWrapper } from "@/use/ModelWrapper";
+
+    export default {
+        name: "RestrictionsSection",
+        props: {
+            errorBag: {
+                required: true,
+                type: ErrorBag,
+            },
+            start: {
+                required: true,
+                type: String,
+            },
+            end: {
+                required: true,
+                type: String,
+            },
+        },
+        setup(props: any, { emit }: any) {
+            return {
+                startDate: useModelWrapper(props, emit, "start"),
+                endDate: useModelWrapper(props, emit, "end"),
+            };
+        },
+    };
+</script>

--- a/src/use/ModelWrapper.ts
+++ b/src/use/ModelWrapper.ts
@@ -1,0 +1,8 @@
+import { computed } from "vue";
+
+export function useModelWrapper(props: any, emit: any, name = "modelValue") {
+    return computed({
+        get: () => props[name],
+        set: (value) => emit(`update:${name}`, value),
+    });
+}

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -8,101 +8,13 @@
         <h1 class="text-2xl font-medium text-gray-700 mb-8">{{ heading }}</h1>
 
         <div>
-
-            <basics-section :error-bag="errorBag"
-                            v-model:course-type="course.courseType"
-                            v-model:course-name="course.courseName"
-                            v-model:course-description="course.courseDescription"
-                            v-model:course-language="course.courseLanguage"/>
-
-
-            <section class="border-t-2 py-8 border-gray-400">
-                <div class="lg:flex">
-                    <div class="w-full lg:w-1/3 lg:block mr-12 flex flex-col mb-4">
-                        <label class="block text-gray-700 text-lg font-medium mb-2">Basics</label>
-                        <label class="block text-gray-600">
-                            This is some long detailed description which is part towards a better form.
-                        </label>
-                    </div>
-                    <div class="w-full lg:w-2/3">
-                        <div class="mb-4 flex flex-col">
-                            <!-- TODO: create cards for better visual impact -->
-                            <label class="text-gray-700 text-md font-medium mb-3">Type</label>
-                            <div class="flex">
-                                <div v-for="courseType in courseTypes" :key="courseType" class="mr-4">
-                                    <label class="flex items-center">
-                                        <input
-                                            v-model="course.courseType"
-                                            type="radio"
-                                            class="form-radio radio"
-                                            name="type"
-                                            :value="courseType"
-                                        />
-                                        <span class="ml-2 text-gray-700 text-md font-medium">{{ courseType }}</span>
-                                    </label>
-                                </div>
-                            </div>
-                            <p v-if="errorBag.has('courseType')" class="error-message">
-                                {{ errorBag.get("courseType") }}
-                            </p>
-                        </div>
-                        <div class="mb-4 flex flex-col">
-                            <label for="name" class="text-gray-700 text-md font-medium mb-3">Name</label>
-                            <input
-                                id="name"
-                                v-model="course.courseName"
-                                type="text"
-                                name="courseName"
-                                class="w-full form-input input-text"
-                                :class="{ error: errorBag.has('courseName') }"
-                                placeholder="Course Name"
-                            />
-                            <p v-if="errorBag.has('courseName')" class="error-message">
-                                {{ errorBag.get("courseName") }}
-                            </p>
-                        </div>
-                        <div class="mb-4 flex flex-col">
-                            <label class="text-gray-700 text-md font-medium mb-3">Language</label>
-                            <select
-                                id="language"
-                                v-model="course.courseLanguage"
-                                required
-                                name="language"
-                                class="w-full form-select input-select"
-                                :class="{ error: errorBag.has('courseLanguage') }"
-                            >
-                                <option disabled :value="''">Select a Language</option>
-                                <option v-for="language in languages" :key="language">{{ language }}</option>
-                            </select>
-                            <p v-if="errorBag.has('courseLanguage')" class="error-message">
-                                {{ errorBag.get("courseLanguage") }}
-                            </p>
-                        </div>
-                        <div class="mb-4 flex flex-col">
-                            <label for="description" class="text-gray-700 text-md font-medium mb-3">
-                                Description
-                                <span class="text-gray-600 font-normal">
-                                    (Optional)
-                                </span>
-                            </label>
-                            <textarea
-                                id="description"
-                                v-model="course.courseDescription"
-                                name="description"
-                                cols="30"
-                                rows="10"
-                                class="w-full form-textarea border-2 border-gray-400 rounded-lg text-gray-600"
-                                :class="{ error: errorBag.has('courseDescription') }"
-                                placeholder="Add an optional description."
-                            >
-                            </textarea>
-                            <p v-if="errorBag.has('courseDescription')" class="error-message">
-                                {{ errorBag.get("courseDescription") }}
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </section>
+            <basics-section
+                v-model:name="course.courseName"
+                v-model:type="course.courseType"
+                v-model:language="course.courseLanguage"
+                v-model:description="course.courseDescription"
+                :error-bag="errorBag"
+            />
 
             <section class="border-t-2 py-8 border-gray-400">
                 <div class="lg:flex">

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -8,6 +8,14 @@
         <h1 class="text-2xl font-medium text-gray-700 mb-8">{{ heading }}</h1>
 
         <div>
+
+            <basics-section :error-bag="errorBag"
+                            v-model:course-type="course.courseType"
+                            v-model:course-name="course.courseName"
+                            v-model:course-description="course.courseDescription"
+                            v-model:course-language="course.courseLanguage"/>
+
+
             <section class="border-t-2 py-8 border-gray-400">
                 <div class="lg:flex">
                     <div class="w-full lg:w-1/3 lg:block mr-12 flex flex-col mb-4">
@@ -224,10 +232,12 @@
     import ErrorBag from "@/use/ErrorBag";
     import ValidationResponseHandler from "@/use/ValidationResponseHandler";
     import GenericResponseHandler from "@/use/GenericResponseHandler";
+    import BasicsSection from "@/components/course/edit/BasicsSection.vue";
 
     export default {
         name: "LecturerCreateCourseForm",
         components: {
+            BasicsSection,
             DeleteCourseModal,
         },
         props: {

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -112,7 +112,6 @@
             const errorBag: ErrorBag = reactive(new ErrorBag());
 
             if (props.editMode) {
-                const courseManagement: CourseManagement = new CourseManagement();
                 const response = await courseManagement.getCourse(Router.currentRoute.value.params.id as string);
                 const genericResponseHandler = new GenericResponseHandler();
                 const result = genericResponseHandler.handleReponse(response);
@@ -146,7 +145,6 @@
             });
 
             async function createCourse() {
-                const courseManagement: CourseManagement = new CourseManagement();
                 const response = await courseManagement.createCourse(course.value);
                 const handler = new ValidationResponseHandler();
                 success.value = handler.handleReponse(response);

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -48,7 +48,7 @@
                         v-if="editMode"
                         :disabled="!hasInput"
                         type="button"
-                        class="mb-4 w-full w-full btn btn-blue-primary"
+                        class="mb-4 w-full btn btn-blue-primary"
                         @click="updateCourse"
                     >
                         Save Changes

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -16,34 +16,10 @@
                 :error-bag="errorBag"
             />
 
-            <section class="border-t-2 py-8 border-gray-400">
-                <div class="lg:flex">
-                    <div class="w-full lg:w-1/3 lg:block mr-12 flex flex-col mb-4">
-                        <label class="block text-gray-700 text-md font-medium mb-2">Restrictions</label>
-                        <label class="block text-gray-600">
-                            This is some long detailed description which is part towards a better form.
-                        </label>
-                    </div>
-                    <div class="w-full lg:w-2/3">
-                        <div class="mb-4 flex flex-col">
-                            <label for="limit" class="text-gray-700 text-md font-medium mb-3">Participation Limit</label>
-                            <input
-                                id="limit"
-                                v-model="course.maxParticipants"
-                                type="number"
-                                name="maxParticipants"
-                                min="0"
-                                max="999"
-                                class="w-full form-input input-text"
-                                :class="{ error: errorBag.has('maxParticipants') }"
-                            />
-                            <p v-if="errorBag.has('maxParticipants')" class="error-message">
-                                {{ errorBag.get("maxParticipants") }}
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </section>
+            <restrictions-section
+                v-model:participants-limit="course.maxParticipants"
+                :error-bag="errorBag"
+            />
 
             <section class="border-t-2 py-8 border-gray-400">
                 <div class="lg:flex">
@@ -145,11 +121,13 @@
     import ValidationResponseHandler from "@/use/ValidationResponseHandler";
     import GenericResponseHandler from "@/use/GenericResponseHandler";
     import BasicsSection from "@/components/course/edit/BasicsSection.vue";
+    import RestrictionsSection from "@/components/course/edit/RestrictionsSection.vue";
 
     export default {
         name: "LecturerCreateCourseForm",
         components: {
             BasicsSection,
+            RestrictionsSection,
             DeleteCourseModal,
         },
         props: {

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -159,12 +159,10 @@
             },
         },
 
-        async setup(props: any, { emit }) {
+        async setup(props: any, { emit }: any) {
             let course = ref(new CourseEntity());
             let initialCourseState = new CourseEntity();
             let heading = props.editMode ? "Edit Course" : "Create Course";
-            let languages = Object.values(Language).filter((e) => e != Language.NONE);
-            let courseTypes = Object.values(CourseType).filter((e) => e != CourseType.NONE);
             let success = ref(false);
             const courseManagement: CourseManagement = new CourseManagement();
             let deleteModal = ref();
@@ -276,8 +274,6 @@
                 course,
                 initialCourseState,
                 heading,
-                languages,
-                courseTypes,
                 success,
                 hasInput,
                 isValid,

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -15,50 +15,9 @@
                 v-model:description="course.courseDescription"
                 :error-bag="errorBag"
             />
+            <restrictions-section v-model:participants-limit="course.maxParticipants" :error-bag="errorBag" />
+            <time-section v-model:start="course.startDate" v-model:end="course.endDate" :error-bag="errorBag" />
 
-            <restrictions-section
-                v-model:participants-limit="course.maxParticipants"
-                :error-bag="errorBag"
-            />
-
-            <section class="border-t-2 py-8 border-gray-400">
-                <div class="lg:flex">
-                    <div class="w-full lg:w-1/3 lg:block mr-12 flex flex-col mb-4">
-                        <label class="block text-gray-700 text-md font-medium mb-2">Time</label>
-                        <label class="block text-gray-600">
-                            This section is disabled for now as there is no Vue3 datepicker plugin yet.
-                        </label>
-                    </div>
-                    <div class="w-full lg:w-2/3 flex">
-                        <div class="w-1/2 mb-4 mr-12 flex flex-col">
-                            <label for="start" class="text-gray-700 text-md font-medium mb-3">Start Date</label>
-                            <input
-                                id="start"
-                                v-model="course.startDate"
-                                type="text"
-                                readonly
-                                name="startDate"
-                                class="w-full form-input input-text"
-                                :class="{ error: errorBag.has('startDate') }"
-                            />
-                            <p v-if="errorBag.has('startDate')" class="error-message">{{ errorBag.get("startDate") }}</p>
-                        </div>
-                        <div class="w-1/2 mb-4 flex flex-col">
-                            <label for="end" class="text-gray-700 text-md font-medium mb-3">End Date</label>
-                            <input
-                                id="end"
-                                v-model="course.endDate"
-                                type="text"
-                                readonly
-                                name="endDate"
-                                class="w-full form-input input-text"
-                                :class="{ error: errorBag.has('endDate') }"
-                            />
-                            <p v-if="errorBag.has('endDate')" class="error-message">{{ errorBag.get("endDate") }}</p>
-                        </div>
-                    </div>
-                </div>
-            </section>
             <section class="border-t-2 py-8 border-gray-400 lg:mt-8">
                 <div class="hidden sm:flex justify-between">
                     <div class="flex justify-start items-center">
@@ -122,12 +81,14 @@
     import GenericResponseHandler from "@/use/GenericResponseHandler";
     import BasicsSection from "@/components/course/edit/BasicsSection.vue";
     import RestrictionsSection from "@/components/course/edit/RestrictionsSection.vue";
+    import TimeSection from "@/components/course/edit/TimeSection.vue";
 
     export default {
         name: "LecturerCreateCourseForm",
         components: {
             BasicsSection,
             RestrictionsSection,
+            TimeSection,
             DeleteCourseModal,
         },
         props: {


### PR DESCRIPTION
This PR splits the create/edit course form into multiple subviews so we have more maintainable code. I did however not refactor the setup method at all yet. It's just about the decluttering the template at this point.

The technique used to handle the v-model and props is described in detail [here](https://www.vuemastery.com/blog/vue-3-data-down-events-up/). Essentially, we make use of composable functions to handle the v-modelling/emitting for us. 

If you agree with this strategy, I would implement this also for the CreateEditAccount form and all future subsections. 
