### PR TITLE
Feature/implement api errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Feature
 - add password change API + unit test (#213)
-- 
+- adds errors for nested objects, like the street of one's address (#233)
+
 # [v.0.4.4](https://github.com/upb-uc4/ui-web/compare/v0.4.3...v0.4.4) (2020-07-22)
 
 - Requires backend version 0.4.2

--- a/src/use/ErrorBag.ts
+++ b/src/use/ErrorBag.ts
@@ -7,8 +7,17 @@ export default class ErrorBag {
         return this.errors.some((e) => e.name === key);
     }
 
+    hasNested(key: string): boolean {
+        return this.errors.some((e) => e.name.endsWith(key));
+    }
+
     get(key: string): string | undefined {
         const error = this.errors.find((e) => e.name === key);
+        return error?.reason;
+    }
+
+    getNested(key: string): string | undefined {
+        const error = this.errors.find((e) => e.name.endsWith(key));
         return error?.reason;
     }
 

--- a/src/views/admin/EditCreateAccountForm.vue
+++ b/src/views/admin/EditCreateAccountForm.vue
@@ -30,7 +30,7 @@
                                     </label>
                                 </div>
                             </div>
-                            <p v-if="errorBag.has('role')" class="error-message">{{ errorBag.get("role") }} bla</p>
+                            <p v-if="errorBag.hasNested('role')" class="error-message">{{ errorBag.getNested("role") }}</p>
                         </div>
                     </div>
                 </div>
@@ -52,11 +52,11 @@
                                 v-model="account.user.username"
                                 type="text"
                                 class="w-full form-input input-text"
-                                :class="{ error: errorBag.has('username') }"
+                                :class="{ error: errorBag.hasNested('username') }"
                                 placeholder="Username"
                                 :readonly="editMode"
                             />
-                            <p v-if="errorBag.has('username')" class="error-message">{{ errorBag.get("username") }}</p>
+                            <p v-if="errorBag.hasNested('username')" class="error-message">{{ errorBag.getNested("username") }}</p>
                         </div>
                         <div class="mb-4 flex flex-col">
                             <label class="text-gray-700 text-md font-medium mb-3">Email</label>
@@ -68,7 +68,7 @@
                                 :class="{ error: errorBag.has('email') }"
                                 placeholder="example@mail.com"
                             />
-                            <p v-if="errorBag.has('email')" class="error-message">{{ errorBag.get("email") }}</p>
+                            <p v-if="errorBag.hasNested('email')" class="error-message">{{ errorBag.getNested("email") }}</p>
                         </div>
                         <div v-if="!editMode" class="mb-4 flex flex-col">
                             <label for="password" class="text-gray-700 text-md font-medium mb-3">
@@ -82,7 +82,7 @@
                                 :class="{ error: errorBag.has('password') }"
                                 placeholder="Password"
                             />
-                            <p v-if="errorBag.has('password')" class="error-message">{{ errorBag.get("password") }}</p>
+                            <p v-if="errorBag.hasNested('password')" class="error-message">{{ errorBag.getNested("password") }}</p>
                         </div>
                     </div>
                 </div>
@@ -109,11 +109,11 @@
                                         v-model="account.user.firstName"
                                         type="text"
                                         class="w-full form-input input-text"
-                                        :class="{ error: errorBag.has('firstName') }"
+                                        :class="{ error: errorBag.hasNested('firstName') }"
                                         placeholder="Firstname"
                                     />
-                                    <p v-if="errorBag.has('firstName')" class="error-message">
-                                        {{ errorBag.get("firstName") }}
+                                    <p v-if="errorBag.hasNested('firstName')" class="error-message">
+                                        {{ errorBag.getNested("firstName") }}
                                     </p>
                                 </div>
                                 <div class="w-full pl-2 flex-col">
@@ -123,11 +123,11 @@
                                         v-model="account.user.lastName"
                                         type="text"
                                         class="w-full form-input input-text"
-                                        :class="{ error: errorBag.has('lastName') }"
+                                        :class="{ error: errorBag.hasNested('lastName') }"
                                         placeholder="Lastname"
                                     />
-                                    <p v-if="errorBag.has('lastName')" class="error-message">
-                                        {{ errorBag.get("lastName") }}
+                                    <p v-if="errorBag.hasNested('lastName')" class="error-message">
+                                        {{ errorBag.getNested("lastName") }}
                                     </p>
                                 </div>
                             </div>
@@ -141,25 +141,24 @@
                                 v-model:month="account.birthDate.month"
                                 v-model:day="account.birthDate.day"
                             />
-                            <p v-if="errorBag.has('birthDate')" class="error-message">{{ errorBag.get("birthDate") }}</p>
+                            <p v-if="errorBag.hasNested('birthDate')" class="error-message">{{ errorBag.getNested("birthDate") }}</p>
                         </div>
                         <div class="mb-4 flex flex-col">
                             <label class="text-gray-700 text-md font-medium mb-3">
                                 Adress
                             </label>
-                            <p v-if="errorBag.has('address')" class="error-message">{{ errorBag.get("address") }}</p>
                             <div class="w-full flex flex-col">
                                 <label class="text-gray-700 text-sm">Country</label>
                                 <select
                                     id="country"
                                     v-model="account.user.address.country"
                                     class="w-1/2 mb-4 form-select input-select"
-                                    :class="{ error: errorBag.has('country') }"
+                                    :class="{ error: errorBag.hasNested('country') }"
                                 >
                                     <option :value="''">Select a Country</option>
                                     <option v-for="country in countries" :id="'country-' + country" :key="country">{{ country }}</option>
                                 </select>
-                                <p v-if="errorBag.has('country')" class="error-message">{{ errorBag.get("country") }}</p>
+                                <p v-if="errorBag.hasNested('country')" class="error-message">{{ errorBag.getNested("country") }}</p>
                             </div>
                             <div class="flex flex-row">
                                 <div class="w-full pr-2 mb-4 flex flex-col">
@@ -169,11 +168,11 @@
                                         v-model="account.user.address.street"
                                         type="text"
                                         class="w-full form-input input-text"
-                                        :class="{ error: errorBag.has('street') }"
+                                        :class="{ error: errorBag.hasNested('street') }"
                                         placeholder="Street"
                                     />
-                                    <p v-if="errorBag.has('street')" class="error-message">
-                                        {{ errorBag.get("street") }}
+                                    <p v-if="errorBag.hasNested('street')" class="error-message">
+                                        {{ errorBag.getNested("street") }}
                                     </p>
                                 </div>
                                 <div class="pl-2 flex flex-col">
@@ -183,11 +182,11 @@
                                         v-model="account.user.address.houseNumber"
                                         type="text"
                                         class="w-full form-input input-text"
-                                        :class="{ error: errorBag.has('houseNumber') }"
+                                        :class="{ error: errorBag.hasNested('houseNumber') }"
                                         placeholder="Number"
                                     />
-                                    <p v-if="errorBag.has('houseNumber')" class="error-message">
-                                        {{ errorBag.get("houseNumber") }}
+                                    <p v-if="errorBag.hasNested('houseNumber')" class="error-message">
+                                        {{ errorBag.getNested("houseNumber") }}
                                     </p>
                                 </div>
                             </div>
@@ -199,11 +198,11 @@
                                         v-model="account.user.address.zipCode"
                                         type="text"
                                         class="w-full form-input input-text"
-                                        :class="{ error: errorBag.has('zipCode') }"
+                                        :class="{ error: errorBag.hasNested('zipCode') }"
                                         placeholder="Zip Code"
                                     />
-                                    <p v-if="errorBag.has('zipCode')" class="error-message">
-                                        {{ errorBag.get("zipCode") }}
+                                    <p v-if="errorBag.hasNested('zipCode')" class="error-message">
+                                        {{ errorBag.getNested("zipCode") }}
                                     </p>
                                 </div>
                                 <div class="w-full pl-2 flex flex-col">
@@ -213,10 +212,10 @@
                                         v-model="account.user.address.city"
                                         type="text"
                                         class="w-full form-input input-text"
-                                        :class="{ error: errorBag.has('city') }"
+                                        :class="{ error: errorBag.hasNested('city') }"
                                         placeholder="City"
                                     />
-                                    <p v-if="errorBag.has('city')" class="error-message">{{ errorBag.get("city") }}</p>
+                                    <p v-if="errorBag.hasNested('city')" class="error-message">{{ errorBag.getNested("city") }}</p>
                                 </div>
                             </div>
                         </div>
@@ -241,11 +240,11 @@
                                 cols="30"
                                 rows="5"
                                 class="w-full form-textarea border-2 border-gray-400 rounded-lg text-gray-600"
-                                :class="{ error: errorBag.has('freeText') }"
+                                :class="{ error: errorBag.hasNested('freeText') }"
                                 placeholder="Add an optional Description for the Lecturer (Publications, Awards ...)"
                             >
                             </textarea>
-                            <p v-if="errorBag.has('freeText')" class="error-message">{{ errorBag.get("freeText") }}</p>
+                            <p v-if="errorBag.hasNested('freeText')" class="error-message">{{ errorBag.getNested("freeText") }}</p>
                         </div>
                         <div class="mb-4 flex flex-col">
                             <label class="text-gray-700 text-sm font-medium mb-3">Fields of Research (optional)</label>
@@ -255,12 +254,12 @@
                                 cols="30"
                                 rows="3"
                                 class="w-full form-textarea border-2 border-gray-400 rounded-lg text-gray-600"
-                                :class="{ error: errorBag.has('researchArea') }"
+                                :class="{ error: errorBag.hasNested('researchArea') }"
                                 placeholder="Add an optional Description of the Lecturer's Fields of Research"
                             >
                             </textarea>
-                            <p v-if="errorBag.has('researchArea')" class="error-message">
-                                {{ errorBag.get("researchArea") }}
+                            <p v-if="errorBag.hasNested('researchArea')" class="error-message">
+                                {{ errorBag.getNested("researchArea") }}
                             </p>
                         </div>
                     </div>
@@ -285,11 +284,11 @@
                                         v-model="account.student.immatriculationStatus"
                                         type="text"
                                         class="w-full form-input input-text"
-                                        :class="{ error: errorBag.has('immatriculationStatus') }"
+                                        :class="{ error: errorBag.hasNested('immatriculationStatus') }"
                                         placeholder="Immatriculation Status"
                                     />
-                                    <p v-if="errorBag.has('immatriculationStatus')" class="error-message">
-                                        {{ errorBag.get("immatriculationStatus") }}
+                                    <p v-if="errorBag.hasNested('immatriculationStatus')" class="error-message">
+                                        {{ errorBag.getNested("immatriculationStatus") }}
                                     </p>
                                 </div>
                                 <div class="w-1/4 flex flex-col pl-2">
@@ -299,11 +298,11 @@
                                         v-model="account.student.matriculationId"
                                         type="text"
                                         class="w-full form-input input-text"
-                                        :class="{ error: errorBag.has('matriculationId') }"
+                                        :class="{ error: errorBag.hasNested('matriculationId') }"
                                         placeholder="Matriculation-ID"
                                     />
-                                    <p v-if="errorBag.has('matriculationId')" class="error-message">
-                                        {{ errorBag.get("matriculationId") }}
+                                    <p v-if="errorBag.hasNested('matriculationId')" class="error-message">
+                                        {{ errorBag.getNested("matriculationId") }}
                                     </p>
                                 </div>
                             </div>
@@ -319,8 +318,8 @@
                                         placeholder="Select a Field of Study"
                                         @changed="updateFieldsOfStudy"
                                     />
-                                    <p v-if="errorBag.has('fieldsOfStudy')" class="error-message">
-                                        {{ errorBag.get("fieldsOfStudy") }}
+                                    <p v-if="errorBag.hasNested('fieldsOfStudy')" class="error-message">
+                                        {{ errorBag.getNested("fieldsOfStudy") }}
                                     </p>
                                 </div>
                                 <div class="w-1/4 pl-2 flex flex-col">
@@ -330,11 +329,11 @@
                                         v-model="account.student.semesterCount"
                                         type="number"
                                         class="w-full form-input input-text"
-                                        :class="{ error: errorBag.has('semesterCount') }"
+                                        :class="{ error: errorBag.hasNested('semesterCount') }"
                                         placeholder="Semester Count"
                                     />
-                                    <p v-if="errorBag.has('semesterCount')" class="error-message">
-                                        {{ errorBag.get("semesterCount") }}
+                                    <p v-if="errorBag.hasNested('semesterCount')" class="error-message">
+                                        {{ errorBag.getNested("semesterCount") }}
                                     </p>
                                 </div>
                             </div>


### PR DESCRIPTION
# Description

Implements issue #183

## Reason for this PR
- Address would just generate one validation error, we want to show an error for every attribute of the address

## Changes in this PR
- errors will look like this: "student.address.street", so we need to support these namings. As we have student/lecturer/admin .address.street, I opted for a fuzzy checking (check using string.endsWith() ). For this, I added two new methods to the error bag.

## Type of change (remove all that don't apply)
- [X] Refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows
- Browser: Chrome

- Frontend: (remove all that don't apply)
  - [X] Development build

- Backend: (remove all that don't apply)
  - [ ] Local backend version X.X.X

# Checklist: (remove all that don't apply)

- [X] I have performed a self-review of my own code
- [X] My changes generate no new linting warnings or console warnings
- [X] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)