### PR TITLE
Refactor/simplify birthdate accountform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Refactor
 - extract searchbar component for better adaptability (#131)
 - extract sections from account form in single components (#238)
+- bundle birthdate logic in birthdate picker component and remove the old birthdate object within the account (#241)
 
 ### Usability
 - rework login error validation (#232)

--- a/src/components/BirthDatePicker.vue
+++ b/src/components/BirthDatePicker.vue
@@ -1,24 +1,24 @@
 <template>
     <div class="flex flex-row">
-        <div class="mr-2 w-full flex flex-col">
-            <label class="text-gray-700 text-sm">Day</label>
-            <select id="day" v-model="shownDay" class="form-select input-select" @change="updateDay($event.target.value)">
+        <div class="flex flex-col w-full mr-2">
+            <label class="text-sm text-gray-700">Day</label>
+            <select id="day" v-model="shownDay" class="form-select input-select">
                 <option disabled :value="''"> Select a Day </option>
                 <option v-for="selectableDay in 31" :id="'day-' + selectableDay" :key="selectableDay">{{ selectableDay }}</option>
             </select>
         </div>
-        <div class="mx-2 w-full flex flex-col">
-            <label class="text-gray-700 text-sm">Month </label>
-            <select id="month" v-model="shownMonth" class="form-select input-select" @change="updateMonth($event.target.value)">
+        <div class="flex flex-col w-full mx-2">
+            <label class="text-sm text-gray-700">Month </label>
+            <select id="month" v-model="shownMonth" class="form-select input-select">
                 <option disabled :value="''"> Select a Month </option>
                 <option v-for="selectableMonth in months" :id="'month-' + selectableMonth" :key="selectableMonth">{{
                     selectableMonth
                 }}</option>
             </select>
         </div>
-        <div class="ml-2 w-full flex flex-col">
-            <label class="text-gray-700 text-sm">Year</label>
-            <select id="year" v-model="shownYear" class="form-select input-select" @change="updateYear($event.target.value)">
+        <div class="flex flex-col w-full ml-2">
+            <label class="text-sm text-gray-700">Year</label>
+            <select id="year" v-model="shownYear" class="form-select input-select">
                 <option disabled :value="''"> Select a Year </option>
                 <option v-for="selectableYear in selectableYears" :id="'year-' + selectableYear" :key="selectableYear">{{
                     selectableYear
@@ -30,30 +30,27 @@
 
 <script lang="ts">
     import { Month } from "@/entities/Month";
-    import { ref } from "vue";
+    import { ref, reactive, computed, watch } from "vue";
     export default {
         name: "BirthDatePicker",
         props: {
-            year: {
-                type: String,
-                required: true,
-            },
-            month: {
-                type: String,
-                required: true,
-            },
-            day: {
+            birthdate: {
                 type: String,
                 required: true,
             },
         },
-        emits: ["update:day", "update:month", "update:year"],
+        emits: ["update:birthdate"],
         setup(props: any, { emit }) {
             let months = Month;
-
-            let shownDay: string = ref(props.day).value == "" ? "" : parseInt(ref(props.day).value).toString();
-            let shownMonth: string = ref(props.month).value == "" ? "" : Object.values(Month)[parseInt(ref(props.month).value) - 1];
-            let shownYear: string = ref(props.year).value;
+            let shownDay = ref("");
+            let shownMonth = ref("");
+            let shownYear = ref("");
+            if (props.birthdate != "") {
+                let dates = props.birthdate.split("-");
+                shownDay.value = dates[2];
+                shownMonth.value = dates[1] == "" ? "" : Object.values(Month)[parseInt(dates[1]) - 1];
+                shownYear.value = dates[0];
+            }
 
             let currentYear = new Date().getFullYear();
             let selectableYears = [];
@@ -61,21 +58,16 @@
                 selectableYears.push(index);
             }
 
-            function updateDay(day: string) {
-                if (parseInt(day) < 10) {
-                    day = "0" + day;
-                }
-                emit("update:day", day);
-            }
-
-            function updateMonth(month: string) {
-                let monthIndex = Object.values(months).indexOf(month as Month) + 1;
-                emit("update:month", monthIndex < 10 ? "0" + monthIndex : monthIndex.toString());
-            }
-
-            function updateYear(year: string) {
-                emit("update:year", year.toString());
-            }
+            watch([shownDay, shownMonth, shownYear], () => {
+                let monthIndex = Object.values(months).indexOf(shownMonth.value as Month) + 1;
+                let date: string =
+                    shownYear.value +
+                    "-" +
+                    (monthIndex < 10 ? "0" + monthIndex : monthIndex.toString()) +
+                    "-" +
+                    (parseInt(shownDay.value) < 10 ? "0" + shownDay.value : shownDay.value);
+                emit("update:birthdate", date);
+            });
 
             return {
                 shownDay,
@@ -83,9 +75,6 @@
                 shownYear,
                 months,
                 selectableYears,
-                updateDay,
-                updateMonth,
-                updateYear,
             };
         },
     };

--- a/src/components/account/edit/PersonalInformationSection.vue
+++ b/src/components/account/edit/PersonalInformationSection.vue
@@ -47,11 +47,7 @@
                     <label class="mb-3 font-medium text-gray-700 text-md">
                         Birthdate
                     </label>
-                    <birth-date-picker
-                        v-model:year="accountBirthdate.year"
-                        v-model:month="accountBirthdate.month"
-                        v-model:day="accountBirthdate.day"
-                    />
+                    <birth-date-picker v-model:birthdate="accountBirthdate" />
                     <p v-if="errorBag.hasNested('birthDate')" class="error-message">{{ errorBag.getNested("birthDate") }}</p>
                 </div>
                 <div class="flex flex-col mb-4">
@@ -166,7 +162,7 @@
                 required: true,
             },
             birthdate: {
-                type: Object,
+                type: String,
                 required: true,
             },
             address: {
@@ -181,20 +177,16 @@
             let accountBirthdate = ref(props.birthdate);
             let accountAddress = ref(props.address);
 
-            watch(accountBirthdate, () => {
-                emit("update:birthdate", accountBirthdate.value);
-            });
-
             watch(accountAddress, () => {
                 emit("update:address", accountAddress.value);
             });
 
             return {
                 countries,
-                accountBirthdate,
                 accountAddress,
                 accountFirstName: useModelWrapper(props, emit, "firstname"),
                 accountLastName: useModelWrapper(props, emit, "lastname"),
+                accountBirthdate: useModelWrapper(props, emit, "birthdate"),
             };
         },
     };

--- a/src/views/admin/EditCreateAccountForm.vue
+++ b/src/views/admin/EditCreateAccountForm.vue
@@ -19,7 +19,7 @@
             <personal-information-section
                 v-model:firstname="account.user.firstName"
                 v-model:lastname="account.user.lastName"
-                v-model:birthdate="account.birthDate"
+                v-model:birthdate="account.user.birthDate"
                 v-model:address="account.user.address"
                 :edit-mode="editMode"
                 :error-bag="errorBag"
@@ -177,11 +177,6 @@
                 admin: new AdminEntity(false),
                 student: new StudentEntity(false),
                 lecturer: new LecturerEntity(false),
-                birthDate: {
-                    day: "",
-                    month: "",
-                    year: "",
-                },
             });
             let initialAccount = {
                 authUser: new Account(),
@@ -189,11 +184,6 @@
                 admin: new AdminEntity(false),
                 student: new StudentEntity(false),
                 lecturer: new LecturerEntity(false),
-                birthDate: {
-                    day: "",
-                    month: "",
-                    year: "",
-                },
             };
 
             let title = props.editMode ? "Account Editing" : "Account Creation";
@@ -223,11 +213,6 @@
                 } else {
                     account.user = result;
                     initialAccount.user = JSON.parse(JSON.stringify(account.user));
-                    let dates = result.birthDate.split("-");
-                    account.birthDate.day = initialAccount.birthDate.day = dates[2];
-                    account.birthDate.month = initialAccount.birthDate.month = dates[1];
-                    account.birthDate.year = initialAccount.birthDate.year = dates[0];
-
                     if (result.role == Role.LECTURER) {
                         account.lecturer = result as Lecturer;
                         initialAccount.lecturer = JSON.parse(JSON.stringify(account.lecturer));
@@ -257,9 +242,7 @@
                     account.user.lastName != initialAccount.user.lastName ||
                     account.user.email != initialAccount.user.email ||
                     //default user birthdate from the form
-                    account.birthDate.day != initialAccount.birthDate.day ||
-                    account.birthDate.month != initialAccount.birthDate.month ||
-                    account.birthDate.year != initialAccount.birthDate.year ||
+                    account.user.birthDate != initialAccount.user.birthDate ||
                     //default user address
                     account.user.address.country != initialAccount.user.address.country ||
                     account.user.address.street != initialAccount.user.address.street ||
@@ -349,7 +332,6 @@
                 const userManagement: UserManagement = new UserManagement();
                 account.authUser.username = account.user.username;
                 account.authUser.role = account.user.role;
-                account.user.birthDate = account.birthDate.year + "-" + account.birthDate.month + "-" + account.birthDate.day;
 
                 var newUser: Student | Lecturer | Admin = assembleAccount();
 
@@ -368,7 +350,6 @@
 
             async function updateAccount() {
                 const userManagement: UserManagement = new UserManagement();
-                account.user.birthDate = account.birthDate.year + "-" + account.birthDate.month + "-" + account.birthDate.day;
                 var adaptedUser: Student | Lecturer | Admin = assembleAccount();
 
                 const response = await userManagement.updateUser(adaptedUser);


### PR DESCRIPTION
# Description

Implements issue #241 

## Reason for this PR
- the logic of the birthdate handling was implemented in the ```EditCreateAccountForm.vue```, although the birthdate itself is set in the subcomponent ```BirthDatePicker.vue```
- We were still using the workaround birthdate object within the account in this form

## Changes in this PR
- Logic of splitting, displaying and assembling the birthdate is now bundled in the ```BirthdatePicker.vue```
- Old workaround object for handling the birthdate within the form is replace, handling and splitting now happens in the child 

## Type of change (remove all that don't apply)
- [x] Refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows
- Browser: Firefox

- Frontend: (remove all that don't apply)
  - [x] Development build
- Backend: (remove all that don't apply)
  - [x] No backend needed to test this
  - [x] Local backend version 0.4.2 (commit hash [533723e])

# Checklist: (remove all that don't apply)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)