### PR TITLE
Rework store usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-# [v.0.4.5 WIP](https://github.com/upb-uc4/ui-web/compare/v0.4.3...v0.4.4) (2020-07-XX)
+# [v.0.4.5](https://github.com/upb-uc4/ui-web/compare/v0.4.3...v0.4.5) (2020-07-29)
 
 ## Feature
 - Add password change API + unit test (#213)
 - adds errors for nested objects, like the street of one's address (#233)
 - Add option for user to change the password (atm. in lecturer private profile, will be moved to a settings page) (#208)
 - Redesign admin account list to have a more modern look [#226](https://github.com/upb-uc4/ui-web/pull/226)
+- Allow re-authentication on page reload (#248)
 
 ## Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ui-web",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "private": true,
     "scripts": {
         "serve": "vue-cli-service serve",

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,19 +5,31 @@
         <div class="w-3/4 fixed bottom-0">
             <p class="text-xs text-right text-gray-700 mb-2 mr-2">Frontend Version {{ version }}</p>
         </div>
+        <login-modal ref="loginModal" />
     </div>
 </template>
 
 <script lang="ts">
-    import { store } from "@/store/store";
+    import { store, useStore } from "@/store/store";
+    import { ref, onMounted } from "vue";
+    import LoginModal from "@/components/modals/LoginModal.vue";
+    import { MutationTypes } from "./store/mutation-types";
 
     export default {
         name: "App",
-        components: {},
+        components: {
+            LoginModal,
+        },
         setup() {
+            let loginModal = ref();
             const version = "v" + process.env.VUE_APP_VERSION;
+
+            onMounted(() => {
+                useStore().commit(MutationTypes.SET_MODAL, loginModal.value.show);
+            });
             return {
                 version,
+                loginModal,
             };
         },
     };

--- a/src/api/Common.ts
+++ b/src/api/Common.ts
@@ -1,4 +1,4 @@
-import { store } from "@/store/store";
+import { useStore } from "@/store/store";
 import axios from "axios";
 import { AxiosInstance } from "axios";
 
@@ -8,7 +8,8 @@ export default class Common {
     _axios: AxiosInstance;
 
     constructor(endpoint: string) {
-        this._authHeader = { auth: store.state.loginData };
+        const store = useStore();
+        this._authHeader = { auth: store.getters.loginData };
         this._requestParameter = { ...this._authHeader, params: {} };
         const instance = axios.create({
             baseURL: process.env.VUE_APP_API_BASE_URL + endpoint,

--- a/src/api/Common.ts
+++ b/src/api/Common.ts
@@ -3,14 +3,12 @@ import axios from "axios";
 import { AxiosInstance } from "axios";
 
 export default class Common {
-    _authHeader: { auth: { username: string; password: string } } = { auth: { username: "", password: "" } };
-    _requestParameter: { auth: { username: string; password: string }; params: any };
+    _authHeader!: Promise<{ auth: { username: string; password: string } }>;
     _axios: AxiosInstance;
 
     constructor(endpoint: string) {
-        const store = useStore();
-        this._authHeader = { auth: store.getters.loginData };
-        this._requestParameter = { ...this._authHeader, params: {} };
+        this._authHeader = this._getLoginData();
+
         const instance = axios.create({
             baseURL: process.env.VUE_APP_API_BASE_URL + endpoint,
             headers: {
@@ -22,11 +20,9 @@ export default class Common {
         this._axios = instance;
     }
 
-    getAuthHeader() {
-        return this._authHeader;
-    }
-
-    setAuthHeader(authHeader: { auth: { username: string; password: string } }) {
-        this._authHeader = authHeader;
+    async _getLoginData() {
+        const store = useStore();
+        const auth = await store.getters.loginData;
+        return { auth: auth };
     }
 }

--- a/src/api/CourseManagement.ts
+++ b/src/api/CourseManagement.ts
@@ -18,13 +18,14 @@ export default class CourseManagement extends Common {
             statusCode: 0,
         };
 
+        const requestParameter = { ...(await this._authHeader), params: {} as any };
         //optional name to search by
         if (name != undefined) {
-            this._requestParameter.params.courseName = name;
+            requestParameter.params.courseName = name;
         }
 
         await this._axios
-            .get(`/courses`, this._requestParameter)
+            .get(`/courses`, requestParameter)
             .then((response: AxiosResponse) => {
                 result.returnValue = response.data as Course[];
                 result.statusCode = response.status;
@@ -50,7 +51,7 @@ export default class CourseManagement extends Common {
         };
 
         await this._axios
-            .get(`/courses/${id}`, this._authHeader)
+            .get(`/courses/${id}`, await this._authHeader)
             .then((response: AxiosResponse) => {
                 result.statusCode = response.status;
                 result.returnValue = response.data as Course;
@@ -75,7 +76,7 @@ export default class CourseManagement extends Common {
         };
 
         await this._axios
-            .post("/courses", course, this._authHeader)
+            .post("/courses", course, await this._authHeader)
             .then((response: AxiosResponse) => {
                 result.statusCode = response.status;
                 result.returnValue = true;
@@ -103,7 +104,7 @@ export default class CourseManagement extends Common {
         const id = course.courseId;
 
         await this._axios
-            .put(`/courses/${id}`, course, this._authHeader)
+            .put(`/courses/${id}`, course, await this._authHeader)
             .then((response: AxiosResponse) => {
                 console.log(response);
                 result.returnValue = true;
@@ -130,7 +131,7 @@ export default class CourseManagement extends Common {
         };
 
         await this._axios
-            .delete(`/courses/${id}`, this._authHeader)
+            .delete(`/courses/${id}`, await this._authHeader)
             .then((response: AxiosResponse) => {
                 result.returnValue = true;
                 result.statusCode = response.status;

--- a/src/api/CourseManagement.ts
+++ b/src/api/CourseManagement.ts
@@ -31,7 +31,6 @@ export default class CourseManagement extends Common {
                 result.statusCode = response.status;
             })
             .catch((error: AxiosError) => {
-                console.log(error);
                 if (error.response) {
                     result.statusCode = error.response.status;
                 } else {
@@ -106,7 +105,6 @@ export default class CourseManagement extends Common {
         await this._axios
             .put(`/courses/${id}`, course, await this._authHeader)
             .then((response: AxiosResponse) => {
-                console.log(response);
                 result.returnValue = true;
                 result.statusCode = response.status;
             })

--- a/src/api/UserManagement.ts
+++ b/src/api/UserManagement.ts
@@ -58,7 +58,6 @@ export default class UserManagement extends Common {
                 result.statusCode = response.status;
             })
             .catch((error: AxiosError) => {
-                console.log(error);
                 if (error.response) {
                     result.statusCode = error.response.status;
                 } else {
@@ -119,7 +118,6 @@ export default class UserManagement extends Common {
         await instance
             .get(`/role/${loginData.username}`, authHeader)
             .then((response: AxiosResponse) => {
-                console.log(response);
                 intermediateResult.statusCode = response.status;
                 intermediateResult.returnValue = response.data.role;
             })
@@ -159,7 +157,6 @@ export default class UserManagement extends Common {
         await this._axios
             .get(`/role/${username}`, await this._authHeader)
             .then((response: AxiosResponse) => {
-                console.log(response);
                 result.statusCode = response.status;
                 result.returnValue = response.data.role;
             })
@@ -244,7 +241,6 @@ export default class UserManagement extends Common {
                 } else {
                     result.networkError = true;
                 }
-                console.log(error);
             });
 
         return result;
@@ -273,7 +269,6 @@ export default class UserManagement extends Common {
                 } else {
                     result.networkError = true;
                 }
-                console.log(error);
             });
 
         return result;
@@ -300,7 +295,6 @@ export default class UserManagement extends Common {
         await this._axios
             .post(`/password/${username}`, acc, await this._authHeader)
             .then((response: AxiosResponse) => {
-                console.log(response);
                 result.returnValue = true;
                 result.statusCode = response.status;
             })
@@ -311,7 +305,6 @@ export default class UserManagement extends Common {
                 } else {
                     result.networkError = true;
                 }
-                console.log(error);
             });
 
         return result;

--- a/src/api/UserManagement.ts
+++ b/src/api/UserManagement.ts
@@ -1,5 +1,5 @@
 import Common from "./Common";
-import { store } from "@/store/store";
+import { useStore } from "@/store/store";
 import User_List from "./api_models/user_management/User_List";
 import { AxiosResponse, AxiosError } from "axios";
 import Student from "./api_models/user_management/Student";
@@ -10,6 +10,7 @@ import { Account } from "@/entities/Account";
 import APIResponse from "./helpers/models/APIResponse";
 import APIError from "./api_models/errors/APIError";
 import ValidationError from "./api_models/errors/ValidationError";
+import { MutationTypes } from "@/store/mutation-types";
 
 export default class UserManagement extends Common {
     constructor() {
@@ -108,9 +109,10 @@ export default class UserManagement extends Common {
             statusCode: response.statusCode,
         };
 
-        store.state.myRole = response.returnValue;
-        store.state.myId = loginData.username;
-        store.state.loginData = loginData;
+        const store = useStore();
+
+        store.commit(MutationTypes.SET_LOGINDATA, loginData);
+        store.commit(MutationTypes.SET_ROLE, response.returnValue);
 
         return result;
     }
@@ -183,7 +185,8 @@ export default class UserManagement extends Common {
     }
 
     async getOwnUser(): Promise<APIResponse<Student | Lecturer | Admin>> {
-        const username = store.state.loginData.username;
+        const store = useStore();
+        const username = store.getters.loginData.username;
         return await this.getSpecificUser(username);
     }
 
@@ -247,8 +250,9 @@ export default class UserManagement extends Common {
     }
 
     async changeOwnPassword(password: string): Promise<APIResponse<boolean>> {
-        const username = store.state.loginData.username;
-        const role = store.state.myRole;
+        const store = useStore();
+        const username = store.getters.loginData.username;
+        const role = await store.getters.role;
 
         const acc: Account = {
             username: username,

--- a/src/components/CourseList.vue
+++ b/src/components/CourseList.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts">
-    import { store } from "@/store/store";
+    import { useStore } from "@/store/store";
     import { Role } from "@/entities/Role";
     import LecturerCourse from "./LecturerCourse.vue";
     import StudentCourse from "./StudentCourse.vue";
@@ -22,12 +22,13 @@
             StudentCourse,
         },
         async setup() {
-            let role = store.state.myRole;
+            const store = useStore();
+            let role = await store.getters.role;
             let roles = Object.values(Role).filter((e) => e != Role.NONE);
             let isLecturer: boolean = role == Role.LECTURER;
             let isStudent: boolean = role == Role.STUDENT;
             let courseManagement: CourseManagement = new CourseManagement();
-            let myId = store.state.myId;
+            let myId = store.getters.loginData.username;
 
             const genericResponseHandler = new GenericResponseHandler();
             const response = await courseManagement.getCourses();

--- a/src/components/modals/EnterPasswordModal.vue
+++ b/src/components/modals/EnterPasswordModal.vue
@@ -33,7 +33,7 @@
     import UserManagement from "@/api/UserManagement";
     import { ref } from "vue";
     import LoginResponseHandler from "@/use/LoginResponseHandler";
-    import { store } from "../../store/store";
+    import { store, useStore } from "../../store/store";
 
     export default {
         components: {
@@ -58,7 +58,8 @@
             async function checkPassword() {
                 checking.value = true;
                 const userManagement: UserManagement = new UserManagement();
-                const response = await userManagement.login({ username: store.state.loginData.username, password: password.value });
+                const store = useStore();
+                const response = await userManagement.login({ username: store.getters.loginData.username, password: password.value });
                 if (loginResponseHandler.handleReponse(response)) {
                     close(action.CONFIRM);
                 } else {

--- a/src/components/modals/EnterPasswordModal.vue
+++ b/src/components/modals/EnterPasswordModal.vue
@@ -33,7 +33,7 @@
     import UserManagement from "@/api/UserManagement";
     import { ref } from "vue";
     import LoginResponseHandler from "@/use/LoginResponseHandler";
-    import { store, useStore } from "../../store/store";
+    import { useStore } from "../../store/store";
 
     export default {
         components: {

--- a/src/components/modals/LoginModal.vue
+++ b/src/components/modals/LoginModal.vue
@@ -1,0 +1,126 @@
+<template>
+    <modal-no-teleport ref="baseModal" :action="action" @cancel="close(action.CANCEL)">
+        <template #header>
+            <p class="text-2xl text-gray-900">Login</p>
+        </template>
+        <div class="flex flex-col">
+            <p>Please enter your authentication credentials.</p>
+            <div class="mb-4 mt-4">
+                <i class="mt-4 m-3 ml-4 fas fa-envelope absolute text-gray-500"></i>
+                <input
+                    id="loginModalEmail"
+                    v-model="email"
+                    class="lg:w-5/6 font-semibold pl-10 form-input input-text"
+                    type="text"
+                    placeholder="Email"
+                    :class="{ error: error }"
+                    @change="hideErrors()"
+                    @keypress.enter="login"
+                />
+            </div>
+
+            <div class="mb-2">
+                <i class="mt-4 m-3 ml-4 fas fa-lock absolute text-gray-500"></i>
+                <input
+                    id="loginModalPassword"
+                    v-model="password"
+                    :type="passwordFieldType"
+                    class="lg:w-5/6 font-semibold pl-10 form-input input-text"
+                    placeholder="Password"
+                    :class="{ error: error }"
+                    @change="hideErrors()"
+                    @keypress.enter="login"
+                />
+                <button
+                    id="togglePassword"
+                    type="button"
+                    tabIndex="-1"
+                    class="absolute ml-3 mt-1 text-gray-500 text-lg hover:text-gray-600 focus:outline-none"
+                    @click="togglePassword"
+                >
+                    <i :class="[isPasswordVisible() ? 'fa-eye-slash' : 'fa-eye']" class="absolute mt-3 ml-1 fas mr-1"></i>
+                </button>
+                <p v-if="error" class="lg:w-3/4 mt-2 error-message">Wrong username or password!</p>
+            </div>
+        </div>
+        <template #footer>
+            <button id="enterPasswordModalCancel" class="mr-10 btn-tertiary" @click="close(action.CANCEL)">Cancel</button>
+            <button id="enterPasswordModalConfirm" class="w-24 py-2 px-2 btn btn-blue-primary" @click="login">
+                Login
+            </button>
+        </template>
+    </modal-no-teleport>
+</template>
+
+<script lang="ts">
+    import ModalNoTeleport from "@/components/modals/ModalNoTeleport.vue";
+    import UserManagement from "@/api/UserManagement";
+    import { ref } from "vue";
+    import LoginResponseHandler from "@/use/LoginResponseHandler";
+    import { useStore } from "../../store/store";
+
+    export default {
+        components: {
+            ModalNoTeleport,
+        },
+        setup() {
+            const baseModal = ref();
+            let email = ref("");
+            let password = ref("");
+            let error = ref(false);
+            let passwordFieldType = ref("password");
+            let loginResponseHandler: LoginResponseHandler = new LoginResponseHandler();
+
+            enum action {
+                CANCEL,
+                LOGIN,
+            }
+
+            function isPasswordVisible() {
+                return passwordFieldType.value === "text";
+            }
+
+            function hideErrors() {
+                error.value = false;
+            }
+
+            function togglePassword() {
+                passwordFieldType.value = isPasswordVisible() ? "password" : "text";
+            }
+
+            async function show() {
+                return await baseModal.value.show();
+            }
+
+            async function login() {
+                const response = await UserManagement.login({ username: email.value, password: password.value });
+                if (loginResponseHandler.handleReponse(response)) {
+                    close(action.LOGIN);
+                } else {
+                    error.value = true;
+                }
+            }
+
+            function close(action: action) {
+                password.value = "";
+                error.value = false;
+                baseModal.value.close(action);
+            }
+
+            return {
+                email,
+                login,
+                baseModal,
+                error,
+                password,
+                show,
+                close,
+                action,
+                isPasswordVisible,
+                hideErrors,
+                togglePassword,
+                passwordFieldType,
+            };
+        },
+    };
+</script>

--- a/src/components/modals/ModalNoTeleport.vue
+++ b/src/components/modals/ModalNoTeleport.vue
@@ -1,0 +1,83 @@
+<template>
+    <transition name="fade">
+        <div v-show="isVisible" class="fixed w-full h-full top-0 left-0 flex items-center justify-center">
+            <div class="absolute w-full h-full bg-gray-900 opacity-25" />
+
+            <div class="bg-white w-full -mt-32 md:max-w-md lg:max-w-lg xl:max-w-xl mx-auto rounded-lg shadow-xl z-50 overflow-y-auto">
+                <div class="py-8 px-10">
+                    <div class="flex justify-between items-center">
+                        <slot name="header"></slot>
+                        <button id="baseModalCancel" class="cursor-pointer z-50 focus:outline-none" @click="$emit('cancel')">
+                            <svg
+                                class="fill-current text-gray-600 hover:text-gray-700"
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="28"
+                                height="28"
+                                viewBox="0 0 18 18"
+                            >
+                                <path
+                                    d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"
+                                ></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="flex mt-4 mr-8 text-lg text-gray-600 leading-relaxed tracking-wide">
+                        <slot></slot>
+                    </div>
+                </div>
+
+                <div class="bg-gray-200 h-20 flex items-center justify-end">
+                    <div class="flex justify-end mr-10">
+                        <slot name="footer"></slot>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </transition>
+</template>
+
+<script lang="ts">
+    import { ref } from "vue";
+
+    export default {
+        props: {
+            action: {
+                required: true,
+                type: Object,
+            },
+        },
+        emits: ["cancel"],
+        setup(props: any) {
+            const isVisible = ref(false);
+
+            let promiseResolve: (action: typeof props.action) => void = () => {
+                return;
+            };
+
+            function show() {
+                isVisible.value = true;
+                return new Promise(function (resolve) {
+                    promiseResolve = resolve;
+                });
+            }
+
+            function close(action: typeof props.action) {
+                isVisible.value = false;
+                promiseResolve(action);
+            }
+
+            return { isVisible, show, close };
+        },
+    };
+</script>
+
+<style scoped>
+    .fade-enter-active,
+    .fade-leave-active {
+        transition: opacity 0.25s;
+    }
+    .fade-enter-from,
+    .fade-leave-to {
+        opacity: 0;
+    }
+</style>

--- a/src/components/profile/Wrapper.vue
+++ b/src/components/profile/Wrapper.vue
@@ -16,6 +16,7 @@
     import { store } from "@/store/store";
     import { Role } from "@/entities/Role";
     import LoadingComponent from "../../components/loading/Spinner.vue";
+    import { checkPrivilege } from "@/use/PermissionHelper";
 
     export default {
         components: {
@@ -23,12 +24,17 @@
             PublicProfile,
             LoadingComponent,
         },
-        beforeRouteEnter(_from: any, _to: any, next: any) {
-            const myRole = store.state.myRole;
-            if (myRole == Role.NONE) {
-                return next("/redirect");
+        async beforeRouteEnter(_from: any, _to: any, next: any) {
+            const response = await checkPrivilege(Role.LECTURER, Role.STUDENT, Role.ADMIN);
+
+            if (response.allowed) {
+                return next();
             }
-            return next();
+            if (!response.authenticated) {
+                return next("/login");
+            }
+
+            return next("/redirect");
         },
         props: {
             isPrivate: {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -9,28 +9,27 @@ type AugmentedActionContext = {
 } & Omit<ActionContext<State, State>, "commit">;
 
 export interface Actions {
-    [ActionTypes.GET_ID]({ commit }: AugmentedActionContext, payload: string): Promise<string>;
-
-    [ActionTypes.GET_ROLE]({ commit }: AugmentedActionContext, payload: string): Promise<string>;
+    // [ActionTypes.GET_ID]({ commit }: AugmentedActionContext, payload: string): Promise<string>;
+    // [ActionTypes.GET_ROLE]({ commit }: AugmentedActionContext, payload: string): Promise<string>;
 }
 
 export const actions: ActionTree<State, State> & Actions = {
-    [ActionTypes.GET_ID]({ commit }) {
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                const data = "";
-                commit(MutationTypes.SET_ID, data);
-                resolve(data);
-            }, 500);
-        });
-    },
-    [ActionTypes.GET_ROLE]({ commit }) {
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                const data = "256";
-                commit(MutationTypes.SET_ROLE, data);
-                resolve(data);
-            }, 500);
-        });
-    },
+    // [ActionTypes.GET_ID]({ commit }) {
+    //     return new Promise((resolve) => {
+    //         setTimeout(() => {
+    //             const data = "";
+    //             commit(MutationTypes.SET_ID, data);
+    //             resolve(data);
+    //         }, 500);
+    //     });
+    // },
+    // [ActionTypes.GET_ROLE]({ commit }) {
+    //     return new Promise((resolve) => {
+    //         setTimeout(() => {
+    //             const data = "256";
+    //             commit(MutationTypes.SET_ROLE, data);
+    //             resolve(data);
+    //         }, 500);
+    //     });
+    // },
 };

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -1,12 +1,37 @@
 import { GetterTree } from "vuex";
 import { State } from "./state";
+import { Role } from "@/entities/Role";
+import UserManagement from "@/api/UserManagement";
+import { useStore } from "./store";
+import GenericResponseHandler from "@/use/GenericResponseHandler";
 
 //example code: https://dev.to/3vilarthas/vuex-typescript-m4j
 export type Getters = {
     doubledCounter(state: State): string;
+    loginData(state: State): { username: string; password: string };
+    role(state: State): Promise<Role>;
 };
 
 export const getters: GetterTree<State, State> & Getters = {
+    loginData: (state) => {
+        if (state.loginData.username == "" && state.loginData.password == "") {
+            state.loginData.username = "admin";
+            state.loginData.password = "admin";
+        }
+
+        return state.loginData;
+    },
+
+    role: async (state) => {
+        if (state.myRole == Role.NONE) {
+            const usermanagement = new UserManagement();
+            const store = useStore();
+            state.myRole = new GenericResponseHandler().handleReponse(await usermanagement.getRole(store.getters.loginData.username));
+        }
+
+        return state.myRole;
+    },
+
     doubledCounter: (state) => {
         return state.myId;
     },

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -27,7 +27,8 @@ export const getters: GetterTree<State, State> & Getters = {
         if (state.myRole == Role.NONE) {
             const usermanagement = new UserManagement();
             const store = useStore();
-            state.myRole = new GenericResponseHandler().handleReponse(await usermanagement.getRole(store.getters.loginData.username));
+            const role: Role = new GenericResponseHandler().handleReponse(await usermanagement.getRole(store.getters.loginData.username));
+            store.commit(MutationTypes.SET_ROLE, role);
         }
 
         return state.myRole;

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -4,6 +4,7 @@ import { Role } from "@/entities/Role";
 import UserManagement from "@/api/UserManagement";
 import { useStore } from "./store";
 import GenericResponseHandler from "@/use/GenericResponseHandler";
+import { MutationTypes } from "./mutation-types";
 
 //example code: https://dev.to/3vilarthas/vuex-typescript-m4j
 export type Getters = {
@@ -15,8 +16,8 @@ export type Getters = {
 export const getters: GetterTree<State, State> & Getters = {
     loginData: (state) => {
         if (state.loginData.username == "" && state.loginData.password == "") {
-            state.loginData.username = "admin";
-            state.loginData.password = "admin";
+            const store = useStore();
+            store.commit(MutationTypes.SET_LOGINDATA, { username: "admin", password: "admin" });
         }
 
         return state.loginData;

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -7,13 +7,16 @@ import GenericResponseHandler from "@/use/GenericResponseHandler";
 import { MutationTypes } from "./mutation-types";
 import { useRouter } from "vue-router";
 import router from "@/router";
+import Lecturer from "@/api/api_models/user_management/Lecturer";
+import Admin from "@/api/api_models/user_management/Admin";
+import Student from "@/api/api_models/user_management/Student";
 
 //example code: https://dev.to/3vilarthas/vuex-typescript-m4j
 export type Getters = {
-    doubledCounter(state: State): string;
     loginData(state: State): Promise<{ username: string; password: string }>;
     syncLoginData(state: State): { username: string; password: string };
     role(state: State): Promise<Role>;
+    user(state: State): Promise<Student | Lecturer | Admin>;
     loggedIn(state: State): boolean;
 };
 
@@ -31,6 +34,16 @@ export const getters: GetterTree<State, State> & Getters = {
     syncLoginData: (state) => {
         return state.loginData;
     },
+    user: async (state) => {
+        if (state.user.username != state.loginData.username) {
+            const usermanagement = new UserManagement();
+            const response = await usermanagement.getOwnUser();
+            const user: Student | Lecturer | Admin = new GenericResponseHandler().handleReponse(response);
+            const store = useStore();
+            store.commit(MutationTypes.SET_USER, user);
+        }
+        return state.user;
+    },
     role: async (state) => {
         if (state.myRole == Role.NONE) {
             const store = useStore();
@@ -44,9 +57,5 @@ export const getters: GetterTree<State, State> & Getters = {
             store.commit(MutationTypes.SET_ROLE, role);
         }
         return state.myRole;
-    },
-
-    doubledCounter: (state) => {
-        return state.myId;
     },
 };

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -5,32 +5,44 @@ import UserManagement from "@/api/UserManagement";
 import { useStore } from "./store";
 import GenericResponseHandler from "@/use/GenericResponseHandler";
 import { MutationTypes } from "./mutation-types";
+import { useRouter } from "vue-router";
+import router from "@/router";
 
 //example code: https://dev.to/3vilarthas/vuex-typescript-m4j
 export type Getters = {
     doubledCounter(state: State): string;
-    loginData(state: State): { username: string; password: string };
+    loginData(state: State): Promise<{ username: string; password: string }>;
+    syncLoginData(state: State): { username: string; password: string };
     role(state: State): Promise<Role>;
+    loggedIn(state: State): boolean;
 };
 
 export const getters: GetterTree<State, State> & Getters = {
-    loginData: (state) => {
+    loggedIn: (state) => {
+        return state.loggedIn;
+    },
+    loginData: async (state) => {
         if (state.loginData.username == "" && state.loginData.password == "") {
-            const store = useStore();
-            store.commit(MutationTypes.SET_LOGINDATA, { username: "admin", password: "admin" });
+            let modal = state.modal;
+            const success = await modal();
         }
-
         return state.loginData;
     },
-
+    syncLoginData: (state) => {
+        return state.loginData;
+    },
     role: async (state) => {
         if (state.myRole == Role.NONE) {
-            const usermanagement = new UserManagement();
             const store = useStore();
-            const role: Role = new GenericResponseHandler().handleReponse(await usermanagement.getRole(store.getters.loginData.username));
+            const username = (await store.getters.loginData).username;
+            if (username == "") {
+                return Role.NONE;
+            }
+            const usermanagement = new UserManagement();
+            const response = await usermanagement.getRole(username);
+            const role: Role = new GenericResponseHandler().handleReponse(response);
             store.commit(MutationTypes.SET_ROLE, role);
         }
-
         return state.myRole;
     },
 

--- a/src/store/mutation-types.ts
+++ b/src/store/mutation-types.ts
@@ -2,4 +2,6 @@ export enum MutationTypes {
     SET_ID = "SET_ID",
     SET_ROLE = "SET_ROLE",
     SET_LOGINDATA = "SET_LOGINDATA",
+    SET_LOGGEDIN = "SET_LOGGEDIN",
+    SET_MODAL = "SET_MODAL",
 }

--- a/src/store/mutation-types.ts
+++ b/src/store/mutation-types.ts
@@ -1,4 +1,5 @@
 export enum MutationTypes {
     SET_ID = "SET_ID",
     SET_ROLE = "SET_ROLE",
+    SET_LOGINDATA = "SET_LOGINDATA",
 }

--- a/src/store/mutation-types.ts
+++ b/src/store/mutation-types.ts
@@ -4,4 +4,5 @@ export enum MutationTypes {
     SET_LOGINDATA = "SET_LOGINDATA",
     SET_LOGGEDIN = "SET_LOGGEDIN",
     SET_MODAL = "SET_MODAL",
+    SET_USER = "SET_USER",
 }

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,12 +6,20 @@ import { Role } from "@/entities/Role";
 export type Mutations<S = State> = {
     [MutationTypes.SET_ID](state: S, payload: string): void;
     [MutationTypes.SET_ROLE](state: S, payload: string): void;
+    [MutationTypes.SET_MODAL](state: S, payload: string): void;
+    [MutationTypes.SET_LOGGEDIN](state: S, payload: boolean): void;
     [MutationTypes.SET_LOGINDATA](state: S, payload: { username: string; password: string }): void;
 };
 
 export const mutations: MutationTree<State> & Mutations = {
     [MutationTypes.SET_ID](state: State, payload: string) {
         state.myId = payload;
+    },
+    [MutationTypes.SET_MODAL](state: State, payload: any) {
+        state.modal = payload;
+    },
+    [MutationTypes.SET_LOGGEDIN](state: State, payload: boolean) {
+        state.loggedIn = payload;
     },
     [MutationTypes.SET_ROLE](state: State, payload: Role) {
         state.myRole = payload;

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -2,9 +2,12 @@ import { MutationTypes } from "./mutation-types";
 import { State } from "./state";
 import { MutationTree } from "vuex";
 import { Role } from "@/entities/Role";
+import Student from "@/api/api_models/user_management/Student";
+import Lecturer from "@/api/api_models/user_management/Lecturer";
+import Admin from "@/api/api_models/user_management/Admin";
 
 export type Mutations<S = State> = {
-    [MutationTypes.SET_ID](state: S, payload: string): void;
+    [MutationTypes.SET_USER](state: S, payload: Student | Lecturer | Admin): void;
     [MutationTypes.SET_ROLE](state: S, payload: string): void;
     [MutationTypes.SET_MODAL](state: S, payload: string): void;
     [MutationTypes.SET_LOGGEDIN](state: S, payload: boolean): void;
@@ -12,9 +15,6 @@ export type Mutations<S = State> = {
 };
 
 export const mutations: MutationTree<State> & Mutations = {
-    [MutationTypes.SET_ID](state: State, payload: string) {
-        state.myId = payload;
-    },
     [MutationTypes.SET_MODAL](state: State, payload: any) {
         state.modal = payload;
     },
@@ -26,5 +26,8 @@ export const mutations: MutationTree<State> & Mutations = {
     },
     [MutationTypes.SET_LOGINDATA](state: State, payload: { username: string; password: string }) {
         state.loginData = payload;
+    },
+    [MutationTypes.SET_USER](state: State, payload: Student | Lecturer | Admin) {
+        state.user = payload;
     },
 };

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,6 +6,7 @@ import { Role } from "@/entities/Role";
 export type Mutations<S = State> = {
     [MutationTypes.SET_ID](state: S, payload: string): void;
     [MutationTypes.SET_ROLE](state: S, payload: string): void;
+    [MutationTypes.SET_LOGINDATA](state: S, payload: { username: string; password: string }): void;
 };
 
 export const mutations: MutationTree<State> & Mutations = {
@@ -14,5 +15,8 @@ export const mutations: MutationTree<State> & Mutations = {
     },
     [MutationTypes.SET_ROLE](state: State, payload: Role) {
         state.myRole = payload;
+    },
+    [MutationTypes.SET_LOGINDATA](state: State, payload: { username: string; password: string }) {
+        state.loginData = payload;
     },
 };

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -1,6 +1,7 @@
 import { MutationTypes } from "./mutation-types";
 import { State } from "./state";
 import { MutationTree } from "vuex";
+import { Role } from "@/entities/Role";
 
 export type Mutations<S = State> = {
     [MutationTypes.SET_ID](state: S, payload: string): void;
@@ -11,7 +12,7 @@ export const mutations: MutationTree<State> & Mutations = {
     [MutationTypes.SET_ID](state: State, payload: string) {
         state.myId = payload;
     },
-    [MutationTypes.SET_ROLE](state: State, payload: string) {
+    [MutationTypes.SET_ROLE](state: State, payload: Role) {
         state.myRole = payload;
     },
 };

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,13 +1,16 @@
 import { Role } from "@/entities/Role";
+import { Ref, ref } from "vue";
 
 export const state = {
     apiUrl: "",
     myId: "",
     myRole: Role.NONE,
+    loggedIn: false,
     loginData: {
         username: "",
         password: "",
     },
+    modal: {} as any,
 };
 
 export type State = typeof state;

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,7 +1,9 @@
+import { Role } from "@/entities/Role";
+
 export const state = {
     apiUrl: "",
     myId: "",
-    myRole: "",
+    myRole: Role.NONE,
     loginData: {
         username: "",
         password: "",

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,9 +1,12 @@
 import { Role } from "@/entities/Role";
 import { Ref, ref } from "vue";
+import Lecturer from "@/api/api_models/user_management/Lecturer";
+import Student from "@/api/api_models/user_management/Student";
+import Admin from "@/api/api_models/user_management/Admin";
 
 export const state = {
     apiUrl: "",
-    myId: "",
+    user: {} as Student | Lecturer | Admin,
     myRole: Role.NONE,
     loggedIn: false,
     loginData: {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -9,6 +9,7 @@ export const store = createStore({
     getters,
     mutations,
     actions,
+    strict: true,
 });
 
 export function useStore() {

--- a/src/use/GenericResponseHandler.ts
+++ b/src/use/GenericResponseHandler.ts
@@ -3,7 +3,6 @@ import APIResponse from "../api/helpers/models/APIResponse";
 
 export default class GenericResponseHandler implements ResponseHandler<boolean> {
     handleReponse<T>(response: APIResponse<T>): T {
-        console.log(response);
         if (response.networkError) {
             //TODO show toast
             alert("Network Error");

--- a/src/use/LoginResponseHandler.ts
+++ b/src/use/LoginResponseHandler.ts
@@ -3,7 +3,6 @@ import APIResponse from "../api/helpers/models/APIResponse";
 
 export default class LoginResponseHandler implements ResponseHandler<boolean> {
     handleReponse(response: APIResponse<boolean>): boolean {
-        console.log(response);
         if (response.networkError) {
             //TODO show toast
             alert("Network Error");

--- a/src/use/PermissionHelper.ts
+++ b/src/use/PermissionHelper.ts
@@ -1,7 +1,8 @@
 import { Role } from "@/entities/Role";
 import { useStore } from "@/store/store";
 
-export async function checkPrivilege(...roles: Role[]) {
+export async function checkPrivilege(...roles: Role[]): Promise<{ authenticated: boolean; allowed: boolean }> {
     const store = useStore();
-    return roles.includes(await store.getters.role);
+    const role = await store.getters.role;
+    return { authenticated: role != Role.NONE, allowed: roles.includes(role) };
 }

--- a/src/use/PermissionHelper.ts
+++ b/src/use/PermissionHelper.ts
@@ -1,0 +1,7 @@
+import { Role } from "@/entities/Role";
+import { useStore } from "@/store/store";
+
+export async function checkPrivilege(...roles: Role[]) {
+    const store = useStore();
+    return roles.includes(await store.getters.role);
+}

--- a/src/use/ValidationResponseHandler.ts
+++ b/src/use/ValidationResponseHandler.ts
@@ -39,8 +39,6 @@ export default class ValidationResponseHandler implements ResponseHandler<boolea
                 return false;
             }
             case 422: {
-                console.log(response);
-                console.log(this.errorList);
                 return false;
             }
             case 201: {

--- a/src/views/admin/AccountFormSuspenseWrapper.vue
+++ b/src/views/admin/AccountFormSuspenseWrapper.vue
@@ -13,9 +13,9 @@
 <script lang="ts">
     import AdminCreateAccountForm from "./EditCreateAccountForm.vue";
     import LoadingComponent from "../../components/loading/Spinner.vue";
-    import { store } from "@/store/store";
     import { Role } from "@/entities/Role";
     import { ref } from "vue";
+    import { checkPrivilege } from "@/use/PermissionHelper";
     import UnsavedChangesModal from "@/components/modals/UnsavedChangesModal.vue";
 
     export default {
@@ -26,8 +26,10 @@
             UnsavedChangesModal,
         },
 
-        beforeRouteEnter(_to: any, _from: any, next: any) {
-            if (store.state.myRole == Role.ADMIN) {
+        async beforeRouteEnter(_to: any, _from: any, next: any) {
+            const allowed = await checkPrivilege(Role.ADMIN);
+
+            if (allowed) {
                 return next();
             }
             return next("/redirect");

--- a/src/views/admin/AccountFormSuspenseWrapper.vue
+++ b/src/views/admin/AccountFormSuspenseWrapper.vue
@@ -27,11 +27,15 @@
         },
 
         async beforeRouteEnter(_to: any, _from: any, next: any) {
-            const allowed = await checkPrivilege(Role.ADMIN);
+            const response = await checkPrivilege(Role.ADMIN);
 
-            if (allowed) {
+            if (response.allowed) {
                 return next();
             }
+            if (!response.authenticated) {
+                return next("/login");
+            }
+
             return next("/redirect");
         },
 

--- a/src/views/admin/EditCreateAccountForm.vue
+++ b/src/views/admin/EditCreateAccountForm.vue
@@ -542,10 +542,7 @@
                 account.student.fieldsOfStudy = value.value.filter((f: String) => f != FieldOfStudy.NONE);
             }
 
-            function updatePicture() {
-                console.log(account);
-                console.log(initialAccount);
-            }
+            function updatePicture() {}
 
             let hasInput = computed(() => {
                 if (

--- a/src/views/admin/Home.vue
+++ b/src/views/admin/Home.vue
@@ -22,11 +22,15 @@
         },
 
         async beforeRouteEnter(_to: any, _from: any, next: any) {
-            const allowed = await checkPrivilege(Role.ADMIN);
+            const response = await checkPrivilege(Role.ADMIN);
 
-            if (allowed) {
+            if (response.allowed) {
                 return next();
             }
+            if (!response.authenticated) {
+                return next("/login");
+            }
+
             return next("/redirect");
         },
     };

--- a/src/views/admin/Home.vue
+++ b/src/views/admin/Home.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts">
-    import { store } from "../../store/store";
+    import { checkPrivilege } from "../../use/PermissionHelper";
     import { Role } from "../../entities/Role";
     import DevNavBar from "../../components/dev_components/DevNavBar.vue";
     import AdminAccountList from "../../components/AdminAccountList.vue";
@@ -21,12 +21,13 @@
             AdminAccountList,
         },
 
-        beforeRouteEnter(_to: any, _from: any, next: any) {
-            const myRole = store.state.myRole;
-            if (myRole != Role.ADMIN) {
-                return next("/redirect");
+        async beforeRouteEnter(_to: any, _from: any, next: any) {
+            const allowed = await checkPrivilege(Role.ADMIN);
+
+            if (allowed) {
+                return next();
             }
-            return next();
+            return next("/redirect");
         },
     };
 </script>

--- a/src/views/common/Login.vue
+++ b/src/views/common/Login.vue
@@ -70,7 +70,7 @@
 <script lang="ts">
     import DevNavBar from "../../components/dev_components/DevNavBar.vue";
     import Router from "@/router/";
-    import { store } from "../../store/store";
+    import { useStore } from "../../store/store";
     import { Role } from "../../entities/Role";
     import UserManagement from "@/api/UserManagement";
     import { ref } from "vue";
@@ -113,7 +113,8 @@
                 const loginSuccess = loginResponseHandler.handleReponse(response);
 
                 if (loginSuccess) {
-                    switch (store.state.myRole) {
+                    const store = useStore();
+                    switch (await store.getters.role) {
                         case Role.ADMIN: {
                             Router.push("/admin");
                             break;

--- a/src/views/common/Login.vue
+++ b/src/views/common/Login.vue
@@ -70,10 +70,10 @@
 <script lang="ts">
     import DevNavBar from "../../components/dev_components/DevNavBar.vue";
     import Router from "@/router/";
-    import { useStore } from "../../store/store";
+    import { useStore, store } from "../../store/store";
     import { Role } from "../../entities/Role";
     import UserManagement from "@/api/UserManagement";
-    import { ref } from "vue";
+    import { ref, onMounted } from "vue";
     import LoginResponseHandler from "@/use/LoginResponseHandler";
 
     export default {
@@ -106,9 +106,7 @@
 
             async function login() {
                 const username = email.value;
-                const userManagement: UserManagement = new UserManagement();
-
-                const response = await userManagement.login({ username: username, password: password.value });
+                const response = await UserManagement.login({ username: username, password: password.value });
 
                 const loginSuccess = loginResponseHandler.handleReponse(response);
 

--- a/src/views/lecturer/CourseFormSuspenseWrapper.vue
+++ b/src/views/lecturer/CourseFormSuspenseWrapper.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
     import LecturerCreateCourseForm from "./EditCreateCourseForm.vue";
     import LoadingComponent from "../../components/loading/Spinner.vue";
-    import { store } from "@/store/store";
+    import { checkPrivilege } from "@/use/PermissionHelper";
     import { Role } from "@/entities/Role";
     import { ref } from "vue";
     import UnsavedChangesModal from "@/components/modals/UnsavedChangesModal.vue";
@@ -26,8 +26,10 @@
             UnsavedChangesModal,
         },
 
-        beforeRouteEnter(_to: any, _from: any, next: any) {
-            if (store.state.myRole == Role.LECTURER) {
+        async beforeRouteEnter(_to: any, _from: any, next: any) {
+            const allowed = await checkPrivilege(Role.LECTURER);
+
+            if (allowed) {
                 return next();
             }
             return next("/redirect");

--- a/src/views/lecturer/CourseFormSuspenseWrapper.vue
+++ b/src/views/lecturer/CourseFormSuspenseWrapper.vue
@@ -27,11 +27,15 @@
         },
 
         async beforeRouteEnter(_to: any, _from: any, next: any) {
-            const allowed = await checkPrivilege(Role.LECTURER);
+            const response = await checkPrivilege(Role.LECTURER);
 
-            if (allowed) {
+            if (response.allowed) {
                 return next();
             }
+            if (!response.authenticated) {
+                return next("/login");
+            }
+
             return next("/redirect");
         },
 

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -126,7 +126,7 @@
             const courseManagement: CourseManagement = new CourseManagement();
             let deleteModal = ref();
             const store = useStore();
-            course.value.lecturerId = store.getters.loginData.username;
+            course.value.lecturerId = (await store.getters.loginData).username;
             course.value.startDate = "2020-06-01";
             course.value.endDate = "2020-08-31";
 

--- a/src/views/lecturer/EditCreateCourseForm.vue
+++ b/src/views/lecturer/EditCreateCourseForm.vue
@@ -88,7 +88,7 @@
 
 <script lang="ts">
     import Router from "@/router/";
-    import { store } from "@/store/store";
+    import { useStore } from "@/store/store";
     import { CourseEntity } from "@/entities/CourseEntity";
     import { CourseType } from "@/entities/CourseType";
     import { Language } from "@/entities/Language";
@@ -125,7 +125,8 @@
             let success = ref(false);
             const courseManagement: CourseManagement = new CourseManagement();
             let deleteModal = ref();
-            course.value.lecturerId = store.state.myId;
+            const store = useStore();
+            course.value.lecturerId = store.getters.loginData.username;
             course.value.startDate = "2020-06-01";
             course.value.endDate = "2020-08-31";
 

--- a/src/views/lecturer/Home.vue
+++ b/src/views/lecturer/Home.vue
@@ -10,7 +10,7 @@
 
 <script lang="ts">
     import CourseList from "../../components/LecturerCourseList.vue";
-    import { store } from "../../store/store";
+    import { checkPrivilege } from "../../use/PermissionHelper";
     import { Role } from "../../entities/Role";
     import DevNavBar from "../../components/dev_components/DevNavBar.vue";
 
@@ -21,12 +21,13 @@
             DevNavBar,
         },
 
-        beforeRouteEnter(_to: any, _from: any, next: any) {
-            const myRole = store.state.myRole;
-            if (myRole != Role.LECTURER) {
-                return next("/redirect");
+        async beforeRouteEnter(_to: any, _from: any, next: any) {
+            const allowed = await checkPrivilege(Role.LECTURER);
+
+            if (allowed) {
+                return next();
             }
-            return next();
+            return next("/redirect");
         },
     };
 </script>

--- a/src/views/lecturer/Home.vue
+++ b/src/views/lecturer/Home.vue
@@ -22,11 +22,15 @@
         },
 
         async beforeRouteEnter(_to: any, _from: any, next: any) {
-            const allowed = await checkPrivilege(Role.LECTURER);
+            const response = await checkPrivilege(Role.LECTURER);
 
-            if (allowed) {
+            if (response.allowed) {
                 return next();
             }
+            if (!response.authenticated) {
+                return next("/login");
+            }
+
             return next("/redirect");
         },
     };

--- a/src/views/student/Home.vue
+++ b/src/views/student/Home.vue
@@ -11,7 +11,7 @@
 <script lang="ts">
     import CourseList from "../../components/StudentCourseList.vue";
     import DevNavBar from "../../components/dev_components/DevNavBar.vue";
-    import { store } from "../../store/store";
+    import { checkPrivilege } from "../../use/PermissionHelper";
     import { Role } from "../../entities/Role";
 
     export default {
@@ -20,12 +20,13 @@
             CourseList,
             DevNavBar,
         },
-        beforeRouteEnter(_to: any, _from: any, next: any) {
-            const myRole = store.state.myRole;
-            if (myRole != Role.STUDENT) {
-                return next("/redirect");
+        async beforeRouteEnter(_to: any, _from: any, next: any) {
+            const allowed = await checkPrivilege(Role.STUDENT);
+
+            if (allowed) {
+                return next();
             }
-            return next();
+            return next("/redirect");
         },
     };
 </script>

--- a/src/views/student/Home.vue
+++ b/src/views/student/Home.vue
@@ -21,11 +21,15 @@
             DevNavBar,
         },
         async beforeRouteEnter(_to: any, _from: any, next: any) {
-            const allowed = await checkPrivilege(Role.STUDENT);
+            const response = await checkPrivilege(Role.STUDENT);
 
-            if (allowed) {
+            if (response.allowed) {
                 return next();
             }
+            if (!response.authenticated) {
+                return next("/login");
+            }
+
             return next("/redirect");
         },
     };

--- a/tests/unit/api/courseManagement.spec.ts
+++ b/tests/unit/api/courseManagement.spec.ts
@@ -1,4 +1,3 @@
-import CourseManagement from "@/api/CourseManagement";
 import { Role } from "@/entities/Role";
 import { Account } from "@/entities/Account";
 import { CourseEntity } from "@/entities/CourseEntity";
@@ -6,8 +5,9 @@ import Course from "@/api/api_models/course_management/Course";
 import { Language } from "@/entities/Language";
 import { CourseType } from "@/entities/CourseType";
 import UserManagement from "@/api/UserManagement";
+import CourseManagement from "@/api/CourseManagement";
+import { store } from "@/store/store";
 
-var userManagement: UserManagement;
 var courseManagement: CourseManagement;
 const adminAuth = { username: "admin", password: "admin" };
 const studentAuth = { username: "student", password: "student" };
@@ -17,10 +17,12 @@ var createdCourse: Course = {} as Course;
 jest.useFakeTimers();
 
 beforeAll(async () => {
-    userManagement = new UserManagement();
-    const success = await userManagement.login(lecturerAuth);
-    expect(success.returnValue).toBe(true);
+    console.log("hm");
+    const success = await UserManagement.login(adminAuth);
+    console.log(success);
+    console.log(store.state.loginData);
     courseManagement = new CourseManagement();
+    expect(success.returnValue).toBe(true);
 });
 
 test("Create course", async () => {

--- a/tests/unit/api/courseManagement.spec.ts
+++ b/tests/unit/api/courseManagement.spec.ts
@@ -17,10 +17,7 @@ var createdCourse: Course = {} as Course;
 jest.useFakeTimers();
 
 beforeAll(async () => {
-    console.log("hm");
     const success = await UserManagement.login(adminAuth);
-    console.log(success);
-    console.log(store.state.loginData);
     courseManagement = new CourseManagement();
     expect(success.returnValue).toBe(true);
 });
@@ -38,7 +35,6 @@ test("Create course", async () => {
     course.lecturerId = "lecturer";
     course.maxParticipants = 10;
 
-    console.log(courseManagement._authHeader);
     const success = await courseManagement.createCourse(course);
 
     expect(success.returnValue).toBe(true);

--- a/tests/unit/api/userManagement.spec.ts
+++ b/tests/unit/api/userManagement.spec.ts
@@ -5,14 +5,15 @@ import Student from "@/api/api_models/user_management/Student";
 import Address from "@/api/api_models/user_management/Address";
 import User from "@/api/api_models/user_management/User";
 import { FieldOfStudy } from "@/api/api_models/user_management/FieldOfStudy";
+import { store } from "@/store/store";
 
 var userManagement: UserManagement;
 const adminAuth = { username: "admin", password: "admin" };
 jest.setTimeout(30000);
 
 beforeAll(async () => {
+    const success = await UserManagement.login(adminAuth);
     userManagement = new UserManagement();
-    const success = await userManagement.login(adminAuth);
     expect(success.returnValue).toBe(true);
 });
 
@@ -99,8 +100,11 @@ test("Delete user", async () => {
 test("Change password", async () => {
     let success = await userManagement.changeOwnPassword("testPassword");
     expect(success.returnValue).toBe(true);
-    await new Promise((r) => setTimeout(r, 5000));
+    await new Promise((r) => setTimeout(r, 10000));
+
     adminAuth.password = "testPassword";
+    const loginSuccess = await UserManagement.login(adminAuth);
+    userManagement = new UserManagement();
     success = await userManagement.changeOwnPassword("admin");
     expect(success.returnValue).toBe(true);
 });


### PR DESCRIPTION
# Description

Implements issue #170

## Reason for this PR
- As described in the RFC, we currently use the store in an unsafe way, i.e. we can change the variables without commits, which could act as safeguards and make debugging must easier. This should also help with devtools support.
- We also want to be able to login after reloading the page, which is much easier to implement using the store.
- This is also a good preparation for certificate and/or token handling in the future.

## Changes in this PR
- Change all state access to getters and mutations
- Rework login Data getter to automatically prompt a new login modal, if no loginData is present
- add a permissionHelper, which is used to check if a user is allowed to enter a page
- change all api calls to use the new loginData from the store

## Type of change (remove all that don't apply)
- [X] Refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran the unit tests against backend version v0.4.2
- [X] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows Mac
- Browser: Firefox Chrome Safari

- Frontend: (remove all that don't apply)
  - [X] Development build

- Backend: (remove all that don't apply)
  - [X] Local backend version 0.4.2 

# Checklist: (remove all that don't apply)

- [X] I have performed a self-review of my own code
- [X] My changes generate no new linting warnings or console warnings
- [X] I have updated the package.json version if this is a new release candidate (remove is it is not)
- [X] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)