### PR TITLE
move password change to authentication management endpoint and fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v.0.5.1 WIP](https://github.com/upb-uc4/ui-web/compare/v0.5.0...v0.5.1) (2020-08-XX)
+## Refactor
+- Move Password change API endpoint [#293](https://github.com/upb-uc4/ui-web/pull/293)
+- 
 # [v.0.5.0](https://github.com/upb-uc4/ui-web/compare/v0.4.5-hotfix.1...v0.5.0) (2020-07-31)
 
 ## Feature

--- a/src/api/AuthenticationManagement.ts
+++ b/src/api/AuthenticationManagement.ts
@@ -1,4 +1,14 @@
 import Common from "./Common";
+import APIResponse from "./helpers/models/APIResponse";
+import { useStore } from "@/store/store";
+import { Role } from "@/entities/Role";
+import APIError from "./api_models/errors/APIError";
+import { AxiosResponse, AxiosError } from "axios";
+import ValidationError from "./api_models/errors/ValidationError";
+import { Account } from "@/entities/Account";
+import { MutationTypes } from "@/store/mutation-types";
+import UserManagement from "./UserManagement";
+import GenericResponseHandler from "@/use/GenericResponseHandler";
 
 export default class AuthenticationManagement extends Common {
     constructor() {
@@ -7,5 +17,50 @@ export default class AuthenticationManagement extends Common {
 
     static async getVersion(): Promise<String> {
         return super.getVersion("/authentication-management");
+    }
+
+    async changeOwnPassword(password: string): Promise<APIResponse<boolean>> {
+        const store = useStore();
+        const username = (await store.getters.loginData).username;
+        const role = await store.getters.role;
+        console.log(username);
+        console.log(role);
+        const acc: Account = {
+            username: username,
+            password: password,
+            role: role as Role,
+        };
+
+        let result: APIResponse<boolean> = {
+            error: {} as APIError,
+            networkError: false,
+            returnValue: false,
+            statusCode: 0,
+        };
+
+        await this._axios
+            .put(`/users/${username}`, acc, await this._authHeader)
+            .then((response: AxiosResponse) => {
+                result.returnValue = true;
+                result.statusCode = response.status;
+                console.log(response);
+            })
+            .catch((error: AxiosError) => {
+                if (error.response) {
+                    result.statusCode = error.response.status;
+                    result.error = error.response.data as ValidationError;
+                } else {
+                    result.networkError = true;
+                }
+                console.log(error);
+            });
+
+        if (result.returnValue) {
+            const store = useStore();
+            store.commit(MutationTypes.SET_LOGINDATA, { username: username, password: password });
+            store.commit(MutationTypes.SET_LOGGEDIN, true);
+        }
+
+        return result;
     }
 }

--- a/src/api/AuthenticationManagement.ts
+++ b/src/api/AuthenticationManagement.ts
@@ -23,8 +23,6 @@ export default class AuthenticationManagement extends Common {
         const store = useStore();
         const username = (await store.getters.loginData).username;
         const role = await store.getters.role;
-        console.log(username);
-        console.log(role);
         const acc: Account = {
             username: username,
             password: password,

--- a/src/api/AuthenticationManagement.ts
+++ b/src/api/AuthenticationManagement.ts
@@ -50,7 +50,7 @@ export default class AuthenticationManagement extends Common {
                 } else {
                     result.networkError = true;
                 }
-                console.log(error);
+                
             });
 
         if (result.returnValue) {

--- a/src/api/UserManagement.ts
+++ b/src/api/UserManagement.ts
@@ -170,6 +170,7 @@ export default class UserManagement extends Common {
             .then((response: AxiosResponse) => {
                 result.statusCode = response.status;
                 result.returnValue = response.data.role;
+                console.log(response);
             })
             .catch((error: AxiosError) => {
                 if (error.response) {
@@ -177,6 +178,7 @@ export default class UserManagement extends Common {
                 } else {
                     result.networkError = true;
                 }
+                console.log(error);
             });
         return result;
     }
@@ -244,6 +246,7 @@ export default class UserManagement extends Common {
             .then((reponse: AxiosResponse) => {
                 result.statusCode = reponse.status;
                 result.returnValue = true;
+                console.log(reponse);
             })
             .catch((error: AxiosError) => {
                 if (error.response) {
@@ -252,6 +255,7 @@ export default class UserManagement extends Common {
                 } else {
                     result.networkError = true;
                 }
+                console.log(error);
             });
 
         return result;
@@ -269,42 +273,6 @@ export default class UserManagement extends Common {
 
         await this._axios
             .put(`${endpoint}/${user.username}`, user, await this._authHeader)
-            .then((response: AxiosResponse) => {
-                result.returnValue = true;
-                result.statusCode = response.status;
-            })
-            .catch((error: AxiosError) => {
-                if (error.response) {
-                    result.statusCode = error.response.status;
-                    result.error = error.response.data as ValidationError;
-                } else {
-                    result.networkError = true;
-                }
-            });
-
-        return result;
-    }
-
-    async changeOwnPassword(password: string): Promise<APIResponse<boolean>> {
-        const store = useStore();
-        const username = (await store.getters.loginData).username;
-        const role = await store.getters.role;
-
-        const acc: Account = {
-            username: username,
-            password: password,
-            role: role as Role,
-        };
-
-        let result: APIResponse<boolean> = {
-            error: {} as APIError,
-            networkError: false,
-            returnValue: false,
-            statusCode: 0,
-        };
-
-        await this._axios
-            .post(`/password/${username}`, acc, await this._authHeader)
             .then((response: AxiosResponse) => {
                 result.returnValue = true;
                 result.statusCode = response.status;

--- a/src/api/UserManagement.ts
+++ b/src/api/UserManagement.ts
@@ -246,7 +246,7 @@ export default class UserManagement extends Common {
             .then((reponse: AxiosResponse) => {
                 result.statusCode = reponse.status;
                 result.returnValue = true;
-                console.log(reponse);
+                
             })
             .catch((error: AxiosError) => {
                 if (error.response) {

--- a/src/api/UserManagement.ts
+++ b/src/api/UserManagement.ts
@@ -255,7 +255,7 @@ export default class UserManagement extends Common {
                 } else {
                     result.networkError = true;
                 }
-                console.log(error);
+                
             });
 
         return result;

--- a/src/api/UserManagement.ts
+++ b/src/api/UserManagement.ts
@@ -178,7 +178,7 @@ export default class UserManagement extends Common {
                 } else {
                     result.networkError = true;
                 }
-                console.log(error);
+                
             });
         return result;
     }

--- a/src/api/UserManagement.ts
+++ b/src/api/UserManagement.ts
@@ -170,7 +170,7 @@ export default class UserManagement extends Common {
             .then((response: AxiosResponse) => {
                 result.statusCode = response.status;
                 result.returnValue = response.data.role;
-                console.log(response);
+                
             })
             .catch((error: AxiosError) => {
                 if (error.response) {

--- a/src/components/settings/SecuritySection.vue
+++ b/src/components/settings/SecuritySection.vue
@@ -95,6 +95,7 @@
     import EnterPasswordModal from "@/components/modals/EnterPasswordModal.vue";
     import UserManagement from "@/api/UserManagement";
     import GenericResponseHandler from "@/use/GenericResponseHandler";
+    import AuthenticationManagement from "../../api/AuthenticationManagement";
 
     export default {
         name: "SecuritySection",
@@ -147,13 +148,12 @@
 
             async function updatePassword() {
                 const genericResponseHandler = new GenericResponseHandler();
-                const userManagement: UserManagement = new UserManagement();
-                const response = await userManagement.changeOwnPassword(newPassword.value);
+                const authenticationManagement: AuthenticationManagement = new AuthenticationManagement();
+                const response = await authenticationManagement.changeOwnPassword(newPassword.value);
                 const result = genericResponseHandler.handleReponse(response);
 
                 if (result) {
                     //Remove local inputs (if the user wants to change twice in a row)
-                    store.state.loginData.password = newPassword.value;
                     newPassword.value = "";
                     confirmationPassword.value = "";
                     passwordFieldType.value = "password";

--- a/tests/unit/api/authenticationManagement.spec.ts
+++ b/tests/unit/api/authenticationManagement.spec.ts
@@ -1,0 +1,29 @@
+import UserManagement from "@/api/UserManagement";
+import { store } from "@/store/store";
+import AuthenticationManagement from "@/api/AuthenticationManagement";
+import { MutationTypes } from "@/store/mutation-types";
+
+var authenticationManagement: AuthenticationManagement;
+const studentAuth = { username: "student", password: "student" };
+jest.setTimeout(30000);
+
+beforeAll(async () => {
+    const success = await UserManagement.login(studentAuth);
+    store.commit(MutationTypes.SET_LOGINDATA, studentAuth);
+    store.commit(MutationTypes.SET_LOGGEDIN, true);
+    store.commit(MutationTypes.SET_ROLE, "Student");
+    authenticationManagement = new AuthenticationManagement();
+    expect(success.returnValue).toBe(true);
+});
+
+test("Change password", async () => {
+    let success = await authenticationManagement.changeOwnPassword("testPassword");
+    expect(success.returnValue).toBe(true);
+    await new Promise((r) => setTimeout(r, 10000));
+
+    studentAuth.password = "testPassword";
+
+    authenticationManagement = new AuthenticationManagement();
+    success = await authenticationManagement.changeOwnPassword("student");
+    expect(success.returnValue).toBe(true);
+});

--- a/tests/unit/api/courseManagement.spec.ts
+++ b/tests/unit/api/courseManagement.spec.ts
@@ -7,6 +7,8 @@ import { CourseType } from "@/entities/CourseType";
 import UserManagement from "@/api/UserManagement";
 import CourseManagement from "@/api/CourseManagement";
 import { store } from "@/store/store";
+import { MutationTypes } from "@/store/mutation-types";
+import GenericResponseHandler from "@/use/GenericResponseHandler";
 
 var courseManagement: CourseManagement;
 const adminAuth = { username: "admin", password: "admin" };
@@ -17,7 +19,10 @@ var createdCourse: Course = {} as Course;
 jest.useFakeTimers();
 
 beforeAll(async () => {
-    const success = await UserManagement.login(adminAuth);
+    const success = await UserManagement.login(lecturerAuth);
+    store.commit(MutationTypes.SET_LOGINDATA, lecturerAuth);
+    store.commit(MutationTypes.SET_LOGGEDIN, true);
+    store.commit(MutationTypes.SET_ROLE, "Lecturer");
     courseManagement = new CourseManagement();
     expect(success.returnValue).toBe(true);
 });

--- a/tests/unit/api/userManagement.spec.ts
+++ b/tests/unit/api/userManagement.spec.ts
@@ -6,6 +6,8 @@ import Address from "@/api/api_models/user_management/Address";
 import User from "@/api/api_models/user_management/User";
 import { FieldOfStudy } from "@/api/api_models/user_management/FieldOfStudy";
 import { store } from "@/store/store";
+import { MutationTypes } from "@/store/mutation-types";
+import GenericResponseHandler from "@/use/GenericResponseHandler";
 
 var userManagement: UserManagement;
 const adminAuth = { username: "admin", password: "admin" };
@@ -13,6 +15,9 @@ jest.setTimeout(30000);
 
 beforeAll(async () => {
     const success = await UserManagement.login(adminAuth);
+    store.commit(MutationTypes.SET_LOGINDATA, adminAuth);
+    store.commit(MutationTypes.SET_LOGGEDIN, true);
+    store.commit(MutationTypes.SET_ROLE, "Admin");
     userManagement = new UserManagement();
     expect(success.returnValue).toBe(true);
 });
@@ -28,7 +33,7 @@ var address: Address = {
     houseNumber: "5c",
     zipCode: "42069",
     city: "Mos Eisley",
-    country: "Tatooine",
+    country: "Germany",
 };
 
 var user: User = {
@@ -94,17 +99,5 @@ test("Update user", async () => {
 test("Delete user", async () => {
     await new Promise((r) => setTimeout(r, 5000));
     const success = await userManagement.deleteUser(student.username);
-    expect(success.returnValue).toBe(true);
-});
-
-test("Change password", async () => {
-    let success = await userManagement.changeOwnPassword("testPassword");
-    expect(success.returnValue).toBe(true);
-    await new Promise((r) => setTimeout(r, 10000));
-
-    adminAuth.password = "testPassword";
-    const loginSuccess = await UserManagement.login(adminAuth);
-    userManagement = new UserManagement();
-    success = await userManagement.changeOwnPassword("admin");
     expect(success.returnValue).toBe(true);
 });


### PR DESCRIPTION
# Description

Moves password change endpoint to auth management, as defined and already implemented by lagom (in 0.5.0)

## Type of change (remove all that don't apply)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran the unit tests against backend version v0.4.0
- [X] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows 
- Browser: Chrome

- Frontend: (remove all that don't apply)
  - [X] Development build

- Backend: (remove all that don't apply)
  - [X] Local backend version 0.5.0 

# Checklist: (remove all that don't apply)

- [X] I have performed a self-review of my own code
- [X] My changes generate no new linting warnings or console warnings
- [X] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)