### PR TITLE
add before route enter restrictions to settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [v.0.5.1 WIP](https://github.com/upb-uc4/ui-web/compare/v0.5.0...v0.5.1) (2020-08-XX)
 ## Bug Fixes
 - fix lecturers not seeing their own courses
+- fix missing route enter restrictions of settings page [#294](https://github.com/upb-uc4/ui-web/pull/294)
 
 # [v.0.5.0](https://github.com/upb-uc4/ui-web/compare/v0.4.5-hotfix.1...v0.5.0) (2020-07-31)
 

--- a/src/views/common/Settings.vue
+++ b/src/views/common/Settings.vue
@@ -1,11 +1,11 @@
 <template>
-    <div class="w-full lg:mt-16 mt-8 bg-gray-300 mx-auto h-screen">
+    <div class="w-full h-screen mx-auto mt-8 bg-gray-300 lg:mt-16">
         <button id="navigateBack" class="flex items-center mb-4 navigation-link" @click="back">
-            <i class="fas text-xl fa-chevron-left" />
-            <span class="font-bold text-sm ml-1">Back</span>
+            <i class="text-xl fas fa-chevron-left" />
+            <span class="ml-1 text-sm font-bold">Back</span>
         </button>
 
-        <h1 class="text-2xl font-medium text-gray-700 mb-8">Settings</h1>
+        <h1 class="mb-8 text-2xl font-medium text-gray-700">Settings</h1>
 
         <div>
             <security-section />
@@ -13,15 +13,31 @@
     </div>
 </template>
 
-<script>
-    import SecuritySection from "@/components/settings/SecuritySection";
+<script lang="ts">
+    import SecuritySection from "@/components/settings/SecuritySection.vue";
     import Router from "@/router";
+    import { Role } from "@/entities/Role";
+    import { checkPrivilege } from "@/use/PermissionHelper";
 
     export default {
         name: "Settings",
         components: {
             SecuritySection,
         },
+
+        async beforeRouteEnter(_from: any, _to: any, next: any) {
+            const response = await checkPrivilege(Role.LECTURER, Role.STUDENT, Role.ADMIN);
+
+            if (response.allowed) {
+                return next();
+            }
+            if (!response.authenticated) {
+                return next("/login");
+            }
+
+            return next("/redirect");
+        },
+
         setup() {
             function back() {
                 Router.back();


### PR DESCRIPTION
# Description

Fixes issue #292 

## Reason for this PR
- Bugfix, settings page had no route enter restrictions

## Changes in this PR
- add the same restrictions as for public profiles, as all logged in users have the permission to reach it


## Type of change (remove all that don't apply)

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows 
- Browser: Firefox 

- Frontend: (remove all that don't apply)
  - [x] Development build

- Backend: (remove all that don't apply)
  - [x] No backend needed to test this
  - [x] Deployed develop version 0.5.0


# Checklist: (remove all that don't apply)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)