### PR TITLE
add routing behind UC4 logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## Bug Fixes
 - fix lecturers not seeing their own courses
 
+## Feature
+- add routing to landing page behind logo in navbar [#296](https://github.com/upb-uc4/ui-web/pull/296)
+
 # [v.0.5.0](https://github.com/upb-uc4/ui-web/compare/v0.4.5-hotfix.1...v0.5.0) (2020-07-31)
 
 ## Feature

--- a/src/components/navigation/navbar/common/BaseNavbar.vue
+++ b/src/components/navigation/navbar/common/BaseNavbar.vue
@@ -1,15 +1,15 @@
 <template>
-    <header class="flex lg:px-8 px-4 bg-white justify-between bg-gray-800 items-center md:h-20 min-h-20">
-        <div class="flex w-full items-center">
-            <div class="flex items-center pr-8 mr-8 border-gray-100 border-r-4">
-                <a href="#" class="flex text-3xl font-semibold text-gray-100 tracking-wider">
+    <header class="flex items-center justify-between px-4 bg-gray-800 lg:px-8 md:h-20 min-h-20">
+        <div class="flex items-center w-full">
+            <div class="flex items-center pr-8 mr-8 border-r-4 border-gray-100">
+                <button @click="routeLogo" class="flex text-3xl font-semibold tracking-wider text-gray-100 outline-none">
                     UC4
-                </a>
+                </button>
             </div>
 
             <div class="flex w-full">
-                <nav class="md:flex items-center justify-between w-full" :class="{ hidden: !isBurgerMenuOpen }">
-                    <ul class="md:flex justify-between font-semibold text-gray-100 tracking-wider pt-2">
+                <nav class="items-center justify-between w-full md:flex" :class="{ hidden: !isBurgerMenuOpen }">
+                    <ul class="justify-between pt-2 font-semibold tracking-wider text-gray-100 md:flex">
                         <slot></slot>
                     </ul>
                     <div class="pb-3">
@@ -18,8 +18,8 @@
                 </nav>
             </div>
 
-            <button type="button" class="block md:hidden text-gray-100 hover:text-gray-500 focus:outline-none" @click="toggleBurgerMenu">
-                <svg class="h-8 w-8 fill-current" viewBox="0 0 24 24">
+            <button type="button" class="block text-gray-100 md:hidden hover:text-gray-500 focus:outline-none" @click="toggleBurgerMenu">
+                <svg class="w-8 h-8 fill-current" viewBox="0 0 24 24">
                     <path
                         v-if="isBurgerMenuOpen"
                         fill-rule="evenodd"
@@ -37,18 +37,27 @@
 </template>
 
 <script lang="ts">
-    import { ref } from "vue";
+    import { ref, computed } from "vue";
+    import { useStore } from "@/store/store";
+    import Router from "@/router/index"
 
     export default {
         name: "BaseNavbar",
         setup() {
             const isBurgerMenuOpen = ref(false);
 
+            function routeLogo() {
+                let store = useStore();
+                let loggedIn = store.getters.loggedIn;
+                let logoTargetRoute = loggedIn ? "welcome" : "login";
+                Router.push(logoTargetRoute);
+            }
+
             function toggleBurgerMenu() {
                 isBurgerMenuOpen.value = !isBurgerMenuOpen.value;
             }
 
-            return { isBurgerMenuOpen, toggleBurgerMenu };
+            return { isBurgerMenuOpen, routeLogo, toggleBurgerMenu };
         },
     };
 </script>


### PR DESCRIPTION
# Description

Implements issue #267 

## Reason for this PR
- Logo was already a button, but did not route on a landing page

## Changes in this PR
- the logo is now a button with an underlying on click listener that routes the user to the welcome or the login page


## Type of change (remove all that don't apply)
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows
- Browser: Firefox

- Frontend: (remove all that don't apply)
  - [x] Development build
- Backend: (remove all that don't apply)
  - [x] No backend needed to test this
  
# Checklist: (remove all that don't apply)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)