### PR TITLE
Feature/filter accounts by role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# WIP [v.0.5.2](https://github.com/upb-uc4/ui-web/compare/v0.5.1...v0.5.2) (2020-XX-XX)
+## Feature
+- add filtering by role for the admin account list [#302](https://github.com/upb-uc4/ui-web/pull/302)
+
+
 # [v.0.5.1](https://github.com/upb-uc4/ui-web/compare/v0.5.0...v0.5.1) (2020-08-03)
 ## Refactor
 - Move Password change API endpoint [#293](https://github.com/upb-uc4/ui-web/pull/293)

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -1,6 +1,5 @@
 <template>
     <div class="flex flex-col">
-        <role-filter v-model:selected-role="selectedRole"/>
         <div class="bg-white rounded-lg shadow" v-for="(user, index) in shownUsers" :key="user">
             <user-row :user="user" :is-first-row="index === 0" :is-last-row="index === shownUsers.length - 1" />
         </div>
@@ -14,17 +13,20 @@
     import UserRow from "@/components/account/UserRow.vue";
     import { Role } from "@/entities/Role";
     import { computed, ref } from 'vue';
-    import RoleFilter from "./RoleFilter.vue";
+    
 
     export default {
         name: "AccountList",
         components: {
-            RoleFilter,
             UserRow,
         },
-        async setup() {
-            let selectedRole = ref("All" as Role);
-
+        props: {
+            selectedRole: {
+                type: String,
+                required: true,
+            }
+        },
+        async setup(props:any) {
             const userManagement: UserManagement = new UserManagement();
 
             const genericResponseHandler = new GenericResponseHandler();
@@ -32,12 +34,12 @@
             const userLists = genericResponseHandler.handleReponse(response);
             let users = Object.values(userLists).flat();
             let shownUsers = computed(() => {
-                return selectedRole.value == "All" as Role ? users : users.filter(e => e.role == selectedRole.value)
+                return props.selectedRole == "All" as Role ? users : users.filter(e => e.role == props.selectedRole)
             })
 
             
             return {
-                shownUsers,selectedRole
+                shownUsers
             };
         },
     };

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -1,7 +1,22 @@
 <template>
-    <div class="bg-white rounded-lg shadow flex flex-col">
-        <div v-for="(user, index) in users" :key="user">
-            <user-row :user="user" :is-first-row="index === 0" :is-last-row="index === users.length - 1" />
+    <div class="flex flex-col">
+        <div class="flex justify-between w-1/2 mb-3">
+            <label >Show:</label>
+            <div v-for="vrole in roles" :key="vrole" class="mb-3 mr-4">
+                <label class="flex items-center">
+                    <input
+                        :id="'role-' + vrole"
+                        type="radio"
+                        class="form-radio radio"
+                        v-model="selectedRole"
+                        :value="vrole"
+                    />
+                    <span class="ml-2 font-medium text-gray-700 text-md">{{ vrole }}</span>
+                </label>
+            </div>
+        </div> 
+        <div class="bg-white rounded-lg shadow" v-for="(user, index) in shownUsers" :key="user">
+            <user-row :user="user" :is-first-row="index === 0" :is-last-row="index === shownUsers.length - 1" />
         </div>
     </div>
 </template>
@@ -11,6 +26,8 @@
     import router from "../router";
     import GenericResponseHandler from "@/use/GenericResponseHandler";
     import UserRow from "@/components/account/UserRow.vue";
+    import { Role } from "@/entities/Role"
+    import { computed, ref } from 'vue';
 
     export default {
         name: "AccountList",
@@ -18,15 +35,22 @@
             UserRow,
         },
         async setup() {
+            let roles = Object.values(Role).filter(e => e != Role.NONE);
+            roles.push("All" as Role)
+            let selectedRole = ref("All" as Role);
+
             const userManagement: UserManagement = new UserManagement();
 
             const genericResponseHandler = new GenericResponseHandler();
             const response = await userManagement.getAllUsers();
             const userLists = genericResponseHandler.handleReponse(response);
             let users = Object.values(userLists).flat();
-
+            let shownUsers = computed(() => {
+                return selectedRole.value == "All" as Role ? users : users.filter(e => e.role == selectedRole.value)
+            })
+            
             return {
-                users,
+                roles, shownUsers,selectedRole
             };
         },
     };

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -1,16 +1,6 @@
 <template>
     <div class="flex flex-col">
-        <div class="flex items-baseline w-1/2 mb-3">
-            <div v-for="vrole in roles" :key="vrole" class="mb-3">
-                <label class="inline-flex">
-                    <button 
-                        class="px-4 py-2 text-gray-800 bg-gray-400 border-gray-500 shadow-sm outline-none hover:bg-gray-500" 
-                        :class="{ 'bg-gray-500 shadow-none' : selectedRole == vrole }" @click="select(vrole)">
-                        {{vrole}}
-                    </button>
-                </label>
-            </div>
-        </div> 
+        <role-filter v-model:selected-role="selectedRole"/>
         <div class="bg-white rounded-lg shadow" v-for="(user, index) in shownUsers" :key="user">
             <user-row :user="user" :is-first-row="index === 0" :is-last-row="index === shownUsers.length - 1" />
         </div>
@@ -22,17 +12,17 @@
     import router from "../router";
     import GenericResponseHandler from "@/use/GenericResponseHandler";
     import UserRow from "@/components/account/UserRow.vue";
-    import { Role } from "@/entities/Role"
+    import { Role } from "@/entities/Role";
     import { computed, ref } from 'vue';
+    import RoleFilter from "./RoleFilter.vue";
 
     export default {
         name: "AccountList",
         components: {
+            RoleFilter,
             UserRow,
         },
         async setup() {
-            let roles = Object.values(Role).filter(e => e != Role.NONE);
-            roles.push("All" as Role)
             let selectedRole = ref("All" as Role);
 
             const userManagement: UserManagement = new UserManagement();
@@ -45,12 +35,9 @@
                 return selectedRole.value == "All" as Role ? users : users.filter(e => e.role == selectedRole.value)
             })
 
-            function select(role:string) {
-                selectedRole.value = role as Role;
-            }
             
             return {
-                roles, shownUsers,selectedRole,select
+                shownUsers,selectedRole
             };
         },
     };

--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -1,17 +1,13 @@
 <template>
     <div class="flex flex-col">
-        <div class="flex justify-between w-1/2 mb-3">
-            <label >Show:</label>
-            <div v-for="vrole in roles" :key="vrole" class="mb-3 mr-4">
-                <label class="flex items-center">
-                    <input
-                        :id="'role-' + vrole"
-                        type="radio"
-                        class="form-radio radio"
-                        v-model="selectedRole"
-                        :value="vrole"
-                    />
-                    <span class="ml-2 font-medium text-gray-700 text-md">{{ vrole }}</span>
+        <div class="flex items-baseline w-1/2 mb-3">
+            <div v-for="vrole in roles" :key="vrole" class="mb-3">
+                <label class="inline-flex">
+                    <button 
+                        class="px-4 py-2 text-gray-800 bg-gray-400 border-gray-500 shadow-sm outline-none hover:bg-gray-500" 
+                        :class="{ 'bg-gray-500 shadow-none' : selectedRole == vrole }" @click="select(vrole)">
+                        {{vrole}}
+                    </button>
                 </label>
             </div>
         </div> 
@@ -48,9 +44,13 @@
             let shownUsers = computed(() => {
                 return selectedRole.value == "All" as Role ? users : users.filter(e => e.role == selectedRole.value)
             })
+
+            function select(role:string) {
+                selectedRole.value = role as Role;
+            }
             
             return {
-                roles, shownUsers,selectedRole
+                roles, shownUsers,selectedRole,select
             };
         },
     };

--- a/src/components/AdminAccountList.vue
+++ b/src/components/AdminAccountList.vue
@@ -1,19 +1,20 @@
 <template>
     <div class="w-full max-w-4xl">
-        <div class="flex">
-            <div class="w-full flex flex-row pt-2 mb-8">
+        <div class="flex flex-col">
+            <div class="flex flex-row w-full pt-2 mb-8">
                 <seach-bar v-model:message="message" @refresh="refresh" />
-                <router-link to="/createAccount" class="w-2/12 w- ml-4">
-                    <button title="Add a new User" class="w-full p-2 btn-icon-green items-center justify-center flex flex-row">
+                <router-link to="/createAccount" class="w-2/12 ml-4 w-">
+                    <button title="Add a new User" class="flex flex-row items-center justify-center w-full p-2 btn-icon-green">
                         <p class="mr-3 text-lg font-semibold">Add</p>
-                        <i class="inline fas fa-user-plus text-lg" />
+                        <i class="inline text-lg fas fa-user-plus" />
                     </button>
                 </router-link>
             </div>
+            <role-filter v-model:selected-role="selectedRole"/>
         </div>
         <suspense>
             <template #default>
-                <accountList :key="refreshKey" />
+                <accountList :key="refreshKey" :selected-role="selectedRole" />
             </template>
             <template #fallback>
                 <loading-component />
@@ -33,6 +34,8 @@
     import LoadingComponent from "./loading/Spinner.vue";
     import SeachBar from "./SearchBar.vue";
     import { ref } from "vue";
+    import { Role } from "@/entities/Role"
+    import RoleFilter from "./RoleFilter.vue";
 
     export default {
         name: "AdminAccountList",
@@ -40,10 +43,13 @@
             AccountList,
             LoadingComponent,
             SeachBar,
+            RoleFilter,
         },
         setup() {
             let message = ref("");
             let refreshKey = ref(false);
+
+            let selectedRole = ref("All" as Role);
 
             function refresh() {
                 refreshKey.value = !refreshKey.value;
@@ -52,6 +58,7 @@
                 refreshKey,
                 refresh,
                 message,
+                selectedRole
             };
         },
     };

--- a/src/components/RoleFilter.vue
+++ b/src/components/RoleFilter.vue
@@ -1,0 +1,42 @@
+<template>
+    <div class="flex items-baseline w-1/2 mb-3">
+        <div v-for="vrole in roles" :key="vrole" class="mb-3">
+            <label class="inline-flex">
+                <button 
+                    class="px-4 py-2 text-gray-800 bg-gray-400 border-gray-500 shadow-sm outline-none hover:bg-gray-500" 
+                    :class="{ 'bg-gray-500 shadow-none' : selectedRole == vrole }" @click="select(vrole)">
+                    {{vrole}}
+                </button>
+            </label>
+        </div>
+    </div> 
+</template>
+<script lang="ts">
+import Vue from 'vue'
+    import { Role } from "@/entities/Role"
+    
+    export default {
+        name: "RoleFilter",
+        props: {
+            selectedRole: {
+                type: String,
+                required: true
+            }
+        },
+        emits: [
+            "update:selectedRole"
+        ],
+        setup(props:any, { emit }: any) {
+            let roles = Object.values(Role).filter(e => e != Role.NONE);
+            roles.unshift("All" as Role)
+
+            function select(role:string) {
+                emit("update:selectedRole", role);
+            }
+
+            return {
+                roles, select
+            }
+        }
+    }
+</script>

--- a/src/components/RoleFilter.vue
+++ b/src/components/RoleFilter.vue
@@ -3,8 +3,8 @@
         <div v-for="(vrole,index) in roles" :key="vrole" class="mb-3">
             <label class="inline-flex">
                 <button 
-                    class="px-4 py-2 text-gray-800 bg-gray-400 border-gray-500 shadow-md focus:outline-none hover:bg-gray-500" 
-                    :class="{ 'bg-gray-500 shadow-inner' : selectedRole == vrole , 'rounded-l' : index == 0, 'rounded-r' : index == roles.length-1}" @click="select(vrole)">
+                    class="px-4 py-2 text-gray-800 bg-gray-100 border-gray-200 shadow-md focus:outline-none hover:bg-blue-200" 
+                    :class="{ 'bg-blue-300 text-white hover:bg-blue-300 shadow-inner' : selectedRole == vrole , 'rounded-l' : index == 0, 'rounded-r' : index == roles.length-1}" @click="select(vrole)">
                     {{vrole}}
                 </button>
             </label>

--- a/src/components/RoleFilter.vue
+++ b/src/components/RoleFilter.vue
@@ -3,7 +3,7 @@
         <div v-for="(vrole,index) in roles" :key="vrole" class="mb-3">
             <label class="inline-flex">
                 <button 
-                    class="px-4 py-2 text-gray-800 bg-gray-400 border-gray-500 shadow-md outline-none hover:bg-gray-500" 
+                    class="px-4 py-2 text-gray-800 bg-gray-400 border-gray-500 shadow-md focus:outline-none hover:bg-gray-500" 
                     :class="{ 'bg-gray-500 shadow-inner' : selectedRole == vrole , 'rounded-l' : index == 0, 'rounded-r' : index == roles.length-1}" @click="select(vrole)">
                     {{vrole}}
                 </button>

--- a/src/components/RoleFilter.vue
+++ b/src/components/RoleFilter.vue
@@ -1,10 +1,10 @@
 <template>
     <div class="flex items-baseline w-1/2 mb-3">
-        <div v-for="vrole in roles" :key="vrole" class="mb-3">
+        <div v-for="(vrole,index) in roles" :key="vrole" class="mb-3">
             <label class="inline-flex">
                 <button 
                     class="px-4 py-2 text-gray-800 bg-gray-400 border-gray-500 shadow-sm outline-none hover:bg-gray-500" 
-                    :class="{ 'bg-gray-500 shadow-none' : selectedRole == vrole }" @click="select(vrole)">
+                    :class="{ 'bg-gray-500 shadow-none' : selectedRole == vrole , 'rounded-l' : index == 0, 'rounded-r' : index == roles.length-1}" @click="select(vrole)">
                     {{vrole}}
                 </button>
             </label>

--- a/src/components/RoleFilter.vue
+++ b/src/components/RoleFilter.vue
@@ -3,8 +3,8 @@
         <div v-for="(vrole,index) in roles" :key="vrole" class="mb-3">
             <label class="inline-flex">
                 <button 
-                    class="px-4 py-2 text-gray-800 bg-gray-400 border-gray-500 shadow-sm outline-none hover:bg-gray-500" 
-                    :class="{ 'bg-gray-500 shadow-none' : selectedRole == vrole , 'rounded-l' : index == 0, 'rounded-r' : index == roles.length-1}" @click="select(vrole)">
+                    class="px-4 py-2 text-gray-800 bg-gray-400 border-gray-500 shadow-md outline-none hover:bg-gray-500" 
+                    :class="{ 'bg-gray-500 shadow-inner' : selectedRole == vrole , 'rounded-l' : index == 0, 'rounded-r' : index == roles.length-1}" @click="select(vrole)">
                     {{vrole}}
                 </button>
             </label>


### PR DESCRIPTION
# Description

Implements issue #262 

## Reason for this PR
- The admin did not have any possibility to filter the accounts, he gets from the backend

## Changes in this PR
- I added a simple filter bar consisting of buttons, that allow to filter the shown accounts. To do so, the object containing all users (gotten from the API call in the account list) is just filtered, s.t. no additional API calls like ```getAdmins``` are needed. The filter is set outside the suspense wrapper of the account list itself, s.t. refreshing the account list does not reset the selected filter.

## Type of change (remove all that don't apply)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
- OS: Windows
- Browser: Firefox Chrome 

- Frontend: (remove all that don't apply)
  - [x] Development build
- Backend: (remove all that don't apply)
  - [x] No backend needed to test this
  - [x] Deployed master version 0.5.0
# Checklist: (remove all that don't apply)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)

# Screenshot:
![grafik](https://user-images.githubusercontent.com/63233799/89297638-7d91c400-d664-11ea-98e1-b6d2162ffbb2.png)

