### PR TITLE
Bugfix: Cursor on MegaMenu & hack to keep menu open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   
 ## Bugfix
 - Fix a possible XSS vulnerability [#141](https://github.com/upb-uc4/ui-web/issues/141)
+- Fix cursor styling of menus [#301](https://github.com/upb-uc4/ui-web/issues/301)
+- Fix a bug that made menus close on smaller screen sizes [#306](https://github.com/upb-uc4/ui-web/issues/306)
 
 
 # [v.0.5.1](https://github.com/upb-uc4/ui-web/compare/v0.5.0...v0.5.1) (2020-08-03)

--- a/src/components/navigation/navbar/admin/administration/ManageAccountsMenu.vue
+++ b/src/components/navigation/navbar/admin/administration/ManageAccountsMenu.vue
@@ -4,7 +4,7 @@
         <template #content>
             <div>
                 <!-- hack to keep the menu open even when hovering over the gap between hook and content-->
-                <aside class="absolute bg-transparent lg:w-160 h-8" />
+                <aside class="absolute bg-transparent md:w-48 left-0 lg:w-160 h-8" />
                 <div class="absolute left-0 lg:-left-16 lg:w-64 mt-4 z-30 lg:z-10 bg-white shadow-md rounded-lg overflow-hidden border">
                     <menu-body />
                 </div>

--- a/src/components/navigation/navbar/admin/administration/ManageAccountsMenuBody.vue
+++ b/src/components/navigation/navbar/admin/administration/ManageAccountsMenuBody.vue
@@ -1,7 +1,7 @@
 <template>
     <section class="flex flex-col lg:flex-row px-8 py-6 border-b -mx-4">
         <ul class="w-full px-2">
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="All Users"
                     description="List of all users"
@@ -9,7 +9,7 @@
                     target-route-name="admin.home"
                 />
             </li>
-            <li class="hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="New Account"
                     description="Create a new user"

--- a/src/components/navigation/navbar/common/BaseMenu.vue
+++ b/src/components/navigation/navbar/common/BaseMenu.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="relative" @mouseleave="hide" @mouseover="show">
-        <slot name="hook"></slot>
+        <div class="cursor-default">
+            <slot name="hook"></slot>
+        </div>
+
         <div v-show="isVisible">
             <slot name="content"></slot>
         </div>

--- a/src/components/navigation/navbar/common/BaseMenu.vue
+++ b/src/components/navigation/navbar/common/BaseMenu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="relative cursor-pointer" @mouseleave="hide" @mouseover="show">
+    <div class="relative" @mouseleave="hide" @mouseover="show">
         <slot name="hook"></slot>
         <div v-show="isVisible">
             <slot name="content"></slot>

--- a/src/components/navigation/navbar/common/profile/ProfileMenu.vue
+++ b/src/components/navigation/navbar/common/profile/ProfileMenu.vue
@@ -9,6 +9,7 @@
             </div>
         </template>
         <template #content>
+            <aside class="absolute bg-transparent md:w-48 right-0 h-8" />
             <div class="absolute top-auto right-0 bg-white z-30 lg:z-10 shadow-md rounded-lg overflow-hidden border lg:w-48">
                 <menu-body />
             </div>

--- a/src/components/navigation/navbar/common/profile/ProfileMenuBody.vue
+++ b/src/components/navigation/navbar/common/profile/ProfileMenuBody.vue
@@ -1,13 +1,13 @@
 <template>
     <section class="flex flex-col lg:flex-row px-8 py-6 border-b -mx-4">
         <ul class="w-full px-2">
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item title="Profile" icon-class="fa-user" target-route-name="profile.private" :is-horizontally-aligned="true" />
             </li>
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item title="Settings" icon-class="fa-cog" target-route-name="settings" :is-horizontally-aligned="true" />
             </li>
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="Sign out"
                     icon-class="fa-sign-out-alt"

--- a/src/components/navigation/navbar/lecturer/courses/CourseMenu.vue
+++ b/src/components/navigation/navbar/lecturer/courses/CourseMenu.vue
@@ -4,7 +4,7 @@
         <template #content>
             <div>
                 <!-- hack to keep the menu open even when hovering over the gap between hook and content-->
-                <aside class="absolute bg-transparent lg:w-160 h-8" />
+                <aside class="absolute bg-transparent md:w-48 left-0 lg:w-160 h-8" />
                 <div class="absolute left-0 lg:-left-16 lg:w-160 mt-4 z-30 lg:z-10 bg-white shadow-md rounded-lg overflow-hidden border">
                     <menu-body />
                 </div>

--- a/src/components/navigation/navbar/lecturer/courses/CourseMenuBody.vue
+++ b/src/components/navigation/navbar/lecturer/courses/CourseMenuBody.vue
@@ -1,7 +1,7 @@
 <template>
     <section class="flex flex-col lg:flex-row px-8 py-6 border-b -mx-4">
         <ul class="w-full lg:w-1/2 px-2">
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="All Courses"
                     description="Overview of all courses"
@@ -9,7 +9,7 @@
                     target-route-name="lecturer.home"
                 />
             </li>
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="Create Course"
                     description="Create a new course"
@@ -19,7 +19,7 @@
             </li>
         </ul>
         <ul class="w-full lg:w-1/2 px-4">
-            <li class="hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer hover:bg-gray-200 rounded-lg p-2">
                 <menu-item title="My Courses" description="Courses you created" icon-class="fa-meteor" target-route-name="lecturer.home" />
             </li>
         </ul>

--- a/src/components/navigation/navbar/student/courses/CourseMenu.vue
+++ b/src/components/navigation/navbar/student/courses/CourseMenu.vue
@@ -4,7 +4,7 @@
         <template #content>
             <div>
                 <!-- hack to keep the menu open even when hovering over the gap between hook and content-->
-                <aside class="absolute bg-transparent lg:w-160 h-8" />
+                <aside class="absolute bg-transparent md:w-48 left-0 lg:w-160 h-8" />
                 <div class="absolute left-0 lg:-left-16 lg:w-160 mt-4 z-30 lg:z-10 bg-white shadow-md rounded-lg overflow-hidden border">
                     <menu-body />
                     <menu-footer />

--- a/src/components/navigation/navbar/student/courses/CourseMenuBody.vue
+++ b/src/components/navigation/navbar/student/courses/CourseMenuBody.vue
@@ -1,7 +1,7 @@
 <template>
     <section class="flex flex-col lg:flex-row px-8 py-6 border-b -mx-4">
         <ul class="w-full lg:w-1/2 px-2">
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="All Courses"
                     description="Complete overview of all courses"
@@ -9,7 +9,7 @@
                     target-route-name="student.home"
                 />
             </li>
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="Favorite Courses"
                     description="All courses you marked as favorite"
@@ -17,7 +17,7 @@
                     target-route-name="home"
                 />
             </li>
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="Active Courses"
                     description="Courses you are currently enrolled in"
@@ -27,7 +27,7 @@
             </li>
         </ul>
         <ul class="w-full lg:w-1/2 px-4">
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="My Courses"
                     description="All courses you ever participated in"
@@ -35,7 +35,7 @@
                     target-route-name="home"
                 />
             </li>
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item
                     title="Organisational Stuff"
                     description="Probably meant to click this one"
@@ -43,7 +43,7 @@
                     target-route-name="home"
                 />
             </li>
-            <li class="mb-4 hover:bg-gray-200 rounded-lg p-2">
+            <li class="cursor-pointer mb-4 hover:bg-gray-200 rounded-lg p-2">
                 <menu-item title="Play Chess" description="Check mate" icon-class="fa-chess-knight" target-route-name="home" />
             </li>
         </ul>

--- a/src/components/navigation/navbar/student/courses/CourseMenuFooter.vue
+++ b/src/components/navigation/navbar/student/courses/CourseMenuFooter.vue
@@ -1,7 +1,7 @@
 <template>
     <section class="bg-gray-100 px-2 py-4">
         <ul>
-            <li class="mb-4 hover:bg-gray-300 rounded-lg p-4">
+            <li class="cursor-pointer mb-4 hover:bg-gray-300 rounded-lg p-4">
                 <menu-item
                     title="Roko's Basilisk"
                     description="Hail dear mighty creature"
@@ -10,7 +10,7 @@
                     :is-horizontally-aligned="true"
                 />
             </li>
-            <li class="mb-4 hover:bg-gray-300 rounded-lg p-4">
+            <li class="cursor-pointer mb-4 hover:bg-gray-300 rounded-lg p-4">
                 <menu-item
                     title="Hit the road, Jack"
                     description="Don't you come back no more"
@@ -19,7 +19,7 @@
                     :is-horizontally-aligned="true"
                 />
             </li>
-            <li class="hover:bg-gray-300 rounded-lg p-4">
+            <li class="cursor-pointer hover:bg-gray-300 rounded-lg p-4">
                 <menu-item
                     title="Lift Weights"
                     description="Get big and strong"


### PR DESCRIPTION
# Description

Fixes issues [316](https://github.com/upb-uc4/ui-web/issues/316) and [301](https://github.com/upb-uc4/ui-web/issues/301)
## Reason for this PR
- Improve UX

## Changes in this PR
- Bugfix so that only the menu items are clickable

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the unit tests against backend version v0.5.1
- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows Mac
- Browser: Chrome latest

- Frontend:
  - [x] Development build
- Backend:
  - [x] No backend needed to test this

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)