### PR TITLE
Feature/add house number to private profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - add a timeout of 100ms to prevent refreshing the page too fast (caused application to crash) [#358](https://github.com/upb-uc4/ui-web/pull/358)
 - make a deep copy of address prop in profile address section to avoid directly changing the prop [#381](https://github.com/upb-uc4/ui-web/pull/381)
 - fixes a bug that caused the application to crash if you want to view your own courses without having one
+- add house number to private profile [#398](https://github.com/upb-uc4/ui-web/pull/398)
 
 # [v.0.6.0](https://github.com/upb-uc4/ui-web/compare/v0.5.1...v0.6.0) (2020-08-17)
 ## Feature

--- a/src/components/profile/AddressSection.vue
+++ b/src/components/profile/AddressSection.vue
@@ -47,16 +47,27 @@
                         />
                     </div>
                 </div>
-
-                <div class="mb-6 flex flex-col">
-                    <label class="text-gray-700 text-md font-medium mb-3">Street</label>
-                    <input
-                        id="street"
-                        v-model="editedAddress.street"
-                        type="text"
-                        :readonly="!isEditing"
-                        class="w-full input-text form-input"
-                    />
+                <div class="flex flex-row justify-between">
+                    <div class="mb-6 flex flex-col w-5/6 mr-3">
+                        <label class="text-gray-700 text-md font-medium mb-3">Street</label>
+                        <input
+                            id="street"
+                            v-model="editedAddress.street"
+                            type="text"
+                            :readonly="!isEditing"
+                            class="input-text form-input"
+                        />
+                    </div>
+                    <div class="mb-6 flex flex-col w-1/6">
+                        <label class="text-gray-700 text-md font-medium mb-3">Nr.</label>
+                        <input
+                            id="houseNumber"
+                            v-model="editedAddress.houseNumber"
+                            type="text"
+                            :readonly="!isEditing"
+                            class="input-text form-input"
+                        />
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/components/profile/AddressSection.vue
+++ b/src/components/profile/AddressSection.vue
@@ -25,8 +25,8 @@
                     </select>
                 </div>
 
-                <div class="lg:flex mb-6">
-                    <div class="lg:w-2/3 mb-6 lg:mb-0 flex flex-col lg:mr-16">
+                <div class="lg:flex mb-6 justify-between">
+                    <div class="lg:mb-0 flex flex-col w-5/6 mr-3">
                         <label class="text-gray-700 text-md font-medium mb-3">City</label>
                         <input
                             id="city"
@@ -36,7 +36,7 @@
                             class="w-full input-text form-input"
                         />
                     </div>
-                    <div class="lg:w-1/3 mb-6 lg:mb-0 flex flex-col">
+                    <div class="lg:mb-0 flex flex-col w-1/6">
                         <label class="text-gray-700 text-md font-medium mb-3">Postal Code</label>
                         <input
                             id="zipCode"
@@ -47,8 +47,8 @@
                         />
                     </div>
                 </div>
-                <div class="flex flex-row justify-between">
-                    <div class="mb-6 flex flex-col w-5/6 mr-3">
+                <div class="lg:flex flex-row justify-between mb-6">
+                    <div class="flex flex-col w-5/6 mr-3">
                         <label class="text-gray-700 text-md font-medium mb-3">Street</label>
                         <input
                             id="street"
@@ -58,7 +58,7 @@
                             class="input-text form-input"
                         />
                     </div>
-                    <div class="mb-6 flex flex-col w-1/6">
+                    <div class="flex flex-col w-1/6">
                         <label class="text-gray-700 text-md font-medium mb-3">Nr.</label>
                         <input
                             id="houseNumber"


### PR DESCRIPTION
# Description

Implements issue #380 

## Reason for this PR
- House Number was missing in private profile. It should be editable as well

## Changes in this PR
- add the houseNumber field with v-model


## Type of change (remove all that don't apply)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows
- Browser: Firefox Chrome

- Frontend: (remove all that don't apply)
  - [x] Development build
- Backend: (remove all that don't apply)
  - [x] No backend needed to test this

# Checklist: (remove all that don't apply)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)

# Note:
- E2E tests are missing at this point. As soon as the branch is merged in dev, I will implement them as well on the "test_catch_up" branch because the tests for displaying and changing the private data on the private profile page is already existing there