### PR TITLE
Bugfix/logged in login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - make a deep copy of address prop in profile address section to avoid directly changing the prop [#381](https://github.com/upb-uc4/ui-web/pull/381)
 - fixes a bug that caused the application to crash if you want to view your own courses without having one
 - add house number to private profile [#398](https://github.com/upb-uc4/ui-web/pull/398)
+- prevent user from reaching the login page if already logged in [#406](https://github.com/upb-uc4/ui-web/pull/406)
 
 # [v.0.6.0](https://github.com/upb-uc4/ui-web/compare/v0.5.1...v0.6.0) (2020-08-17)
 ## Feature

--- a/cypress/integration/loginPageLoggedIn.spec.js
+++ b/cypress/integration/loginPageLoggedIn.spec.js
@@ -1,0 +1,13 @@
+describe("Test that you cannot reach the login page via back button after logging in", () => {
+    it("Login as Admin", () => {
+        cy.visit("/");
+        cy.get("input[id='email']").type("admin");
+        cy.get("input[id='password']").type("admin");
+        cy.get('button[id="login"]').click();
+        cy.url().should("contain", "/welcome");
+    });
+    it("Login page not reachable", () => {
+        cy.go(-1);
+        cy.url().should("contain", "/welcome");
+    })
+})

--- a/src/components/navigation/navbar/common/profile/ProfileMenu.vue
+++ b/src/components/navigation/navbar/common/profile/ProfileMenu.vue
@@ -37,7 +37,6 @@
         setup() {
             const store = useStore();
             let user = store.getters.user;
-            console.log(user);
             return { user };
         },
     };

--- a/src/components/navigation/navbar/common/profile/ProfileMenuBody.vue
+++ b/src/components/navigation/navbar/common/profile/ProfileMenuBody.vue
@@ -13,7 +13,7 @@
                     icon-class="fa-sign-out-alt"
                     target-route-name="home"
                     :is-horizontally-aligned="true"
-                    @click="logOut"
+                    @click="logout()"
                 />
             </li>
         </ul>
@@ -29,14 +29,6 @@
         components: {
             MenuItem,
         },
-        setup() {
-            function logOut() {
-                logout();
-            }
-
-            return {
-                logOut,
-            };
-        },
+        setup() {},
     };
 </script>

--- a/src/components/navigation/navbar/common/profile/ProfileMenuBody.vue
+++ b/src/components/navigation/navbar/common/profile/ProfileMenuBody.vue
@@ -22,12 +22,7 @@
 
 <script lang="ts">
     import MenuItem from "../../common/MenuItem.vue";
-    import { useStore } from "../../../../../store/store";
-    import { MutationTypes } from "../../../../../store/mutation-types";
-    import Lecturer from "../../../../../api/api_models/user_management/Lecturer";
-    import Admin from "../../../../../api/api_models/user_management/Admin";
-    import Student from "../../../../../api/api_models/user_management/Student";
-    import { Role } from "../../../../../entities/Role";
+    import { logout } from "@/use/Logout";
 
     export default {
         name: "ProfileMenuBody",
@@ -36,11 +31,7 @@
         },
         setup() {
             function logOut() {
-                const store = useStore();
-                store.commit(MutationTypes.SET_LOGINDATA, { username: "", password: "" });
-                store.commit(MutationTypes.SET_USER, {} as Student | Lecturer | Admin);
-                store.commit(MutationTypes.SET_ROLE, Role.NONE);
-                store.commit(MutationTypes.SET_LOGGEDIN, false);
+                logout();
             }
 
             return {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -13,6 +13,7 @@ import WelcomePage from "../views/common/Welcome.vue";
 import AboutPage from "../views/common/About.vue";
 import { checkPrivilege } from "@/use/PermissionHelper";
 import { Role } from "@/entities/Role";
+import { useStore } from "@/store/store";
 
 const routerHistory = createWebHistory(process.env.BASE_URL);
 const suffix: string = " | UC4";
@@ -198,6 +199,15 @@ const router = createRouter({
 
 router.beforeEach(async (to, from, next) => {
     window.document.title = to.meta && to.meta.title ? to.meta.title : "UC4";
+
+    if (to.name == "login" || to.name == "home") {
+        const store = useStore();
+        if ((await store.getters.loggedIn) != false) {
+            // We need to explicitly set the title here, because the component is not rendered again if going back from "/welcome" to "/login"
+            window.document.title = "Welcome" + suffix;
+            return next("/welcome");
+        }
+    }
 
     const roles: Role[] = to.meta.roles;
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -202,7 +202,7 @@ router.beforeEach(async (to, from, next) => {
 
     if (to.name == "login" || to.name == "home") {
         const store = useStore();
-        if ((await store.getters.loggedIn) != false) {
+        if (await store.getters.loggedIn) {
             // We need to explicitly set the title here, because the component is not rendered again if going back from "/welcome" to "/login"
             window.document.title = "Welcome" + suffix;
             return next("/welcome");

--- a/src/use/Logout.ts
+++ b/src/use/Logout.ts
@@ -1,0 +1,14 @@
+import { useStore } from "@/store/store";
+import { MutationTypes } from "@/store/mutation-types";
+import Lecturer from "@/api/api_models/user_management/Lecturer";
+import Admin from "@/api/api_models/user_management/Admin";
+import Student from "@/api/api_models/user_management/Student";
+import { Role } from "@/entities/Role";
+
+export function logout() {
+    const store = useStore();
+    store.commit(MutationTypes.SET_LOGINDATA, { username: "", password: "" });
+    store.commit(MutationTypes.SET_USER, {} as Student | Lecturer | Admin);
+    store.commit(MutationTypes.SET_ROLE, Role.NONE);
+    store.commit(MutationTypes.SET_LOGGEDIN, false);
+}


### PR DESCRIPTION
# Description

Fixes issue #399 

## Reason for this PR
- A user should not be able to visit the login page if he is already logged in

## Changes in this PR
- Add a method in the beforeEach hook in the router that redirects a logged in user to the welcome page if he routes to the login page (e.g. via the back button)

## Type of change (remove all that don't apply)

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows 
- Browser: Firefox 

- Frontend: (remove all that don't apply)
  - [x] Development build
- Backend: (remove all that don't apply)
  - [x] No backend needed to test this

# Checklist: (remove all that don't apply)

- [x] I added corresponding E2E tests (especially for bugfixes)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)

# Note:
- additionally, I extracted the logout method from the profile menu to a file in the use folder for better reusability (e.g. within the mobile navbar or other possible appearances of logout)