### PR TITLE
supress autocomplete feature for chrome in searchbar

### DIFF
--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -6,6 +6,7 @@
         <input
             id="message"
             v-model="filterMessage"
+            autocomplete="chrome-off"
             class="w-full border-2 border-gray-300 bg-white h-12 px-12 rounded-lg focus:outline-none"
             type="search"
             placeholder="Filter"


### PR DESCRIPTION
# Description

- Fixes #583 

## Reason for this PR
- Search bar suggests filling username in Chrome, which is not fitting.

## Changes in this PR
- Suppress chrome autofill feature for search bar

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Mac
- Browser: Chrome

- Frontend:
  - [x] Development build

- Backend: 
  - [x] No backend needed to test this

# Checklist:

- [ ] I added corresponding E2E tests (especially for bugfixes)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [ ] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)