### PR TITLE
Replace placeholder icons with icons that are already in use in app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - incrementing and decrementing the participation limit with arrow keys or the arrows provided by the browser for number fields, will be registered as changes made to the course and make it saveable [#590](https://github.com/upb-uc4/ui-web/issues/590)
 - remove npm package as it is no longer needed with the official release of Vue3.
 
+## Refactoring
+- Replace placeholder icons in navbars with proper fa icons [#621](https://github.com/upb-uc4/ui-web/issues/621)
+
 # [v.0.10.0](https://github.com/upb-uc4/ui-web/compare/v0.9.1...v0.10.0) (2020-10-09)
 
 ## Bugfix

--- a/src/components/navigation/navbar/desktop/admin/administration/ManageAccountsMenuBody.vue
+++ b/src/components/navigation/navbar/desktop/admin/administration/ManageAccountsMenuBody.vue
@@ -6,7 +6,7 @@
                     id="nav_desktop_admin_menu_manage_accounts_all"
                     title="All Users"
                     description="List of all users"
-                    icon-class="fas fa-list-alt"
+                    icon-class="fas fa-users"
                     target-route-name="accountlist"
                 />
             </li>

--- a/src/components/navigation/navbar/desktop/admin/administration/ManageAccountsMenuBody.vue
+++ b/src/components/navigation/navbar/desktop/admin/administration/ManageAccountsMenuBody.vue
@@ -6,7 +6,7 @@
                     id="nav_desktop_admin_menu_manage_accounts_all"
                     title="All Users"
                     description="List of all users"
-                    icon-class="fa-globe-americas"
+                    icon-class="fas fa-list-alt"
                     target-route-name="accountlist"
                 />
             </li>
@@ -15,7 +15,7 @@
                     id="nav_desktop_admin_menu_manage_accounts_create"
                     title="New Account"
                     description="Create a new user"
-                    icon-class="fa-star"
+                    icon-class="fas fa-user-plus"
                     target-route-name="accountForm.create"
                 />
             </li>

--- a/src/components/navigation/navbar/desktop/admin/courses/CourseMenuBody.vue
+++ b/src/components/navigation/navbar/desktop/admin/courses/CourseMenuBody.vue
@@ -6,7 +6,7 @@
                     id="nav_desktop_admin_menu_courses_all"
                     title="All Courses"
                     description="Overview of all courses"
-                    icon-class="fa-globe-americas"
+                    icon-class="fas fa-list-alt"
                     target-route-name="shared.courses"
                 />
             </li>
@@ -15,7 +15,7 @@
                     id="nav_desktop_admin_menu_courses_create"
                     title="Create Course"
                     description="Create a new course"
-                    icon-class="fa-star"
+                    icon-class="fas fa-calendar-plus"
                     target-route-name="courseForm.create"
                 />
             </li>

--- a/src/components/navigation/navbar/desktop/lecturer/courses/CourseMenuBody.vue
+++ b/src/components/navigation/navbar/desktop/lecturer/courses/CourseMenuBody.vue
@@ -26,7 +26,7 @@
                     id="nav_desktop_lecturer_menu_courses_my_courses"
                     title="My Courses"
                     description="Courses you created"
-                    icon-class="fas fa-list-alt"
+                    icon-class="fas fa-bookmark"
                     target-route-name="lecturer.myCourses"
                 />
             </li>

--- a/src/components/navigation/navbar/desktop/lecturer/courses/CourseMenuBody.vue
+++ b/src/components/navigation/navbar/desktop/lecturer/courses/CourseMenuBody.vue
@@ -6,7 +6,7 @@
                     id="nav_desktop_lecturer_menu_courses_all"
                     title="All Courses"
                     description="Overview of all courses"
-                    icon-class="fa-globe-americas"
+                    icon-class="fas fa-list-alt"
                     target-route-name="shared.courses"
                 />
             </li>
@@ -15,7 +15,7 @@
                     id="nav_desktop_lecturer_menu_courses_create"
                     title="Create Course"
                     description="Create a new course"
-                    icon-class="fa-star"
+                    icon-class="fas fa-calendar-plus"
                     target-route-name="courseForm.create"
                 />
             </li>
@@ -26,7 +26,7 @@
                     id="nav_desktop_lecturer_menu_courses_my_courses"
                     title="My Courses"
                     description="Courses you created"
-                    icon-class="fa-meteor"
+                    icon-class="fas fa-list-alt"
                     target-route-name="lecturer.myCourses"
                 />
             </li>

--- a/src/components/navigation/navbar/desktop/student/courses/CourseMenuBody.vue
+++ b/src/components/navigation/navbar/desktop/student/courses/CourseMenuBody.vue
@@ -6,7 +6,7 @@
                     id="nav_desktop_student_menu_courses_all"
                     title="All Courses"
                     description="Complete overview of all courses"
-                    icon-class="fa-globe-americas"
+                    icon-class="fas fa-list-alt"
                     target-route-name="student.courses"
                 />
             </li>

--- a/src/components/navigation/navbar/mobile/admin/administration/ManageAccountsMenuBody.vue
+++ b/src/components/navigation/navbar/mobile/admin/administration/ManageAccountsMenuBody.vue
@@ -6,7 +6,7 @@
                     id="nav_mobile_admin_menu_manage_accounts_all"
                     title="All Users"
                     description="List of all users"
-                    icon-class="fa-globe-americas"
+                    icon-class="fas fa-list-alt"
                     target-route-name="accountlist"
                 />
             </li>
@@ -15,7 +15,7 @@
                     id="nav_mobile_admin_menu_manage_accounts_create"
                     title="New Account"
                     description="Create a new user"
-                    icon-class="fa-star"
+                    icon-class="fas fa-user-plus"
                     target-route-name="accountForm.create"
                 />
             </li>

--- a/src/components/navigation/navbar/mobile/admin/courses/CourseMenuBody.vue
+++ b/src/components/navigation/navbar/mobile/admin/courses/CourseMenuBody.vue
@@ -5,7 +5,7 @@
                 <menu-item
                     id="nav_mobile_admin_menu_courses_all"
                     title="All Courses"
-                    icon-class="fa-globe-americas"
+                    icon-class="fas fa-list-alt"
                     target-route-name="shared.courses"
                 />
             </li>
@@ -13,7 +13,7 @@
                 <menu-item
                     id="nav_mobile_admin_menu_courses_create"
                     title="Create Course"
-                    icon-class="fa-star"
+                    icon-class="fas fa-calendar-plus"
                     target-route-name="courseForm.create"
                 />
             </li>

--- a/src/components/navigation/navbar/mobile/lecturer/courses/CourseMenuBody.vue
+++ b/src/components/navigation/navbar/mobile/lecturer/courses/CourseMenuBody.vue
@@ -5,7 +5,7 @@
                 <menu-item
                     id="nav_mobile_lecturer_menu_courses_all"
                     title="All Courses"
-                    icon-class="fa-globe-americas"
+                    icon-class="fas fa-list-alt"
                     target-route-name="shared.courses"
                 />
             </li>
@@ -13,7 +13,7 @@
                 <menu-item
                     id="nav_mobile_lecturer_menu_courses_create"
                     title="Create Course"
-                    icon-class="fa-star"
+                    icon-class="fas fa-calendar-plus"
                     target-route-name="courseForm.create"
                 />
             </li>
@@ -21,7 +21,7 @@
                 <menu-item
                     id="nav_mobile_lecturer_menu_courses_my_courses"
                     title="My Courses"
-                    icon-class="fa-meteor"
+                    icon-class="fas fa-list-alt"
                     target-route-name="lecturer.myCourses"
                 />
             </li>

--- a/src/components/navigation/navbar/mobile/student/courses/CourseMenuBody.vue
+++ b/src/components/navigation/navbar/mobile/student/courses/CourseMenuBody.vue
@@ -5,7 +5,7 @@
                 <menu-item
                     id="nav_mobile_student_menu_courses_all"
                     title="All Courses"
-                    icon-class="fa-globe-americas"
+                    icon-class="fas fa-list-alt"
                     target-route-name="student.courses"
                 />
             </li>


### PR DESCRIPTION
# Description

- Fixes #615 
## Changes in this PR
- replace placeholder icons in both navbars (desktop and mobile) with the icons that are already in use throughout our application

## Type of change (remove all that don't apply)
- Refactoring
- New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows
- Browser: Firefox Chrome

- Frontend: (remove all that don't apply)
  - [x] Development build

- Backend: (remove all that don't apply)
  - [x] No backend needed to test this


# Checklist: (remove all that don't apply)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [ ] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)

# Screenshots:
- just for the desktop navbar, mobile uses the same icons
![grafik](https://user-images.githubusercontent.com/63233799/96570060-2f3aab80-12ca-11eb-96db-a0920b039ba7.png)
![grafik](https://user-images.githubusercontent.com/63233799/96570103-3cf03100-12ca-11eb-8377-8c6b0a266187.png)
