### PR TITLE
add a message for the student if not immatriculated to any semester yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [v0.12.1 WIP](https://github.com/upb-uc4/ui-web/compare/v0.12.0...v0.12.1) (2020-XX-XX)
+
+## Refactor
+- add a message for the student if not immatriculated to any semester yet [#692](https://github.com/upb-uc4/ui-web/pull/692)
+
 # [v0.12.0](https://github.com/upb-uc4/ui-web/compare/v0.11.0...v0.12.0) (2020-11-06)
 
 ## Feature

--- a/src/components/profile/student/CourseOfStudySection.vue
+++ b/src/components/profile/student/CourseOfStudySection.vue
@@ -18,6 +18,7 @@
                         class="w-full form-input input-text"
                         placeholder="Matriculation-ID"
                     />
+                    <p v-if="latest == ''" class="mb-3 mt-1 text-xs font-medium text-gray-600">There is no matriculation, yet!</p>
                 </div>
                 <div v-if="latest != ''" class="flex flex-col w-1/2 mt-3">
                     <label class="mb-3 text-sm font-medium text-gray-700 flex">

--- a/src/components/profile/student/CourseOfStudySection.vue
+++ b/src/components/profile/student/CourseOfStudySection.vue
@@ -18,7 +18,7 @@
                         class="w-full form-input input-text"
                         placeholder="Matriculation-ID"
                     />
-                    <p v-if="latest == ''" class="mb-3 mt-1 text-xs font-medium text-gray-600">There is no matriculation, yet!</p>
+                    <p v-if="latest == ''" class="mb-3 mt-1 text-xs font-medium text-gray-600">You have not yet been matriculated!</p>
                 </div>
                 <div v-if="latest != ''" class="flex flex-col w-1/2 mt-3">
                     <label class="mb-3 text-sm font-medium text-gray-700 flex">


### PR DESCRIPTION
# Description
- adds a message for the student if not immatriculated to any semester yet

## Reason for this PR
- If a student was not immatriculated to any semester, he would just have his matriculation id displayed on his profile page, but no feedback whether he is immatriculated. This did not appear until an admin immatriculated him. 

## Changes in this PR
- add a html p element if no latest immatriculation is given

## Type of change (remove all that don't apply)
- Refactoring

# How Has This Been Tested?
- no tests needed

# Checklist: (remove all that don't apply)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)

# Screenshot:
![grafik](https://user-images.githubusercontent.com/63233799/98827757-84845b80-2437-11eb-98c2-5e41012799d1.png)
