### PR TITLE
Hotfix: hide create course button in course catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.13.1-hotfix.1](https://github.com/upb-uc4/ui-web/compare/v0.13.1...v0.13.1-hotfix.1) (2020-11-26)
+## Bugfix
+- hide create course button in course catalogue [#747](https://github.com/upb-uc4/ui-web/pull/747)
+
 # [v0.13.1](https://github.com/upb-uc4/ui-web/compare/v0.13.0...v0.13.1) (2020-11-26)
 
 ## Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [v0.13.1-hotfix.1](https://github.com/upb-uc4/ui-web/compare/v0.13.1...v0.13.1-hotfix.1) (2020-11-26)
+# [v0.13.1-hotfix.1](https://github.com/upb-uc4/ui-web/compare/v0.13.1...v0.13.1-hotfix.1) (2020-11-27)
 ## Bugfix
 - hide create course button in course catalogue [#747](https://github.com/upb-uc4/ui-web/pull/747)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ui-web",
-    "version": "0.13.1",
+    "version": "0.13.1-hotfix.1",
     "private": true,
     "scripts": {
         "serve": "vue-cli-service serve",

--- a/src/use/router/index.ts
+++ b/src/use/router/index.ts
@@ -44,7 +44,7 @@ const router = createRouter({
         {
             path: "/course-catalog",
             name: "courseCatalog",
-            props: { showAllCourses: true },
+            props: { showAllCourses: true, isCourseCatalogue: true },
             component: AllCourseView,
             meta: {
                 title: "Course Catalog" + suffix,

--- a/src/views/common/CourseList.vue
+++ b/src/views/common/CourseList.vue
@@ -55,7 +55,7 @@
             },
             isCourseCatalogue: {
                 type: Boolean,
-                default: () => false,
+                default: false,
             },
         },
         setup(props: any) {

--- a/src/views/common/CourseList.vue
+++ b/src/views/common/CourseList.vue
@@ -4,13 +4,14 @@
         <div class="w-full max-w-4xl">
             <div class="flex flex-col">
                 <div class="flex sm:flex-row flex-col-reverse w-full">
-                    <seach-bar v-model:message="message" class="sm:mr-4" @refresh="refresh" />
+                    <seach-bar v-model:message="message" @refresh="refresh" />
 
                     <router-link
+                        v-if="!isCourseCatalogue"
                         id="createAccountIcon"
                         title="Add a new Course"
                         to="/createCourse"
-                        class="flex flex-row items-center justify-center mb-4 sm:mb-0 sm:w-32 w-full border-2 rounded-lg border-gray-300 h-12 px-12 btn-green-primary-500"
+                        class="sm:ml-4 flex flex-row items-center justify-center mb-4 sm:mb-0 sm:w-32 w-full border-2 rounded-lg border-gray-300 h-12 px-12 btn-green-primary-500"
                     >
                         <p class="mr-3 font-semibold">Add</p>
                         <i class="fas fa-calendar-plus" />
@@ -22,7 +23,7 @@
 
             <course-list :key="refreshKey" :show-all-courses="showAllCourses" :selected-type="selectedType" :filter="message" />
 
-            <div class="flex justify-center mt-16">
+            <div v-if="!isCourseCatalogue" class="flex justify-center mt-16">
                 <router-link to="/createCourse">
                     <button id="addCourse" class="px-4 btn btn-green-primary-500">New Course</button>
                 </router-link>
@@ -51,6 +52,10 @@
             showAllCourses: {
                 type: Boolean,
                 required: true,
+            },
+            isCourseCatalogue: {
+                type: Boolean,
+                default: () => false,
             },
         },
         setup(props: any) {


### PR DESCRIPTION
# Description

- Fixes #746 

## Reason for this PR
- The create course button should not be shown to a user that opens the course catalogue

## Changes in this PR
- use a prop for the component for "tagging" the context of the course list as course catalogue

## Type of change (remove all that don't apply)
- Hotfix

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows Mac Linux
- Browser: Firefox Chrome Safari Chromium

- Frontend: (remove all that don't apply)
  - [x] Development build
- Backend: (remove all that don't apply)
  - [x] No backend needed to test this
# Checklist: (remove all that don't apply)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)