### PR TITLE
Course Info Page Module Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [0.16.1 WIP](https://github.com/upb-uc4/ui-web/compare/v0.15.1...v0.16.0) (2021-XX-XX)
+
+# Refactor
+- show module names as well in course info page [#795](https://github.com/upb-uc4/ui-web/pull/795)
+
 # [0.16.0](https://github.com/upb-uc4/ui-web/compare/v0.15.1...v0.16.0) (2021-01-18)
 ## Feature
 - add a simple data protection agreement page with a placeholder text referring to the university [#792](https://github.com/upb-uc4/ui-web/pull/792)

--- a/src/components/course/info/sections/ModulesSection.vue
+++ b/src/components/course/info/sections/ModulesSection.vue
@@ -74,15 +74,14 @@
 
             async function getModules() {
                 busy.value = true;
+                if ((props.moduleIds as String[]).length == 0) return;
                 const exRegManagement = new ExaminationRegulationManagement();
                 const handler = new GenericResponseHandler("module");
                 const response = await exRegManagement.getModules(props.moduleIds as string[]);
                 let result = handler.handleResponse(response);
-                if (Object.keys(result).length > 0) {
-                    result.forEach((module) => {
-                        optionsArray.value.push({ value: module, display: `${module.id}: ${module.name}` });
-                    });
-                }
+                result.forEach((module) => {
+                    optionsArray.value.push({ value: module, display: `${module.id}: ${module.name}` });
+                });
                 busy.value = false;
             }
 

--- a/tests/e2e/courseAdmission.spec.ts
+++ b/tests/e2e/courseAdmission.spec.ts
@@ -144,6 +144,10 @@ describe("Course Admission", () => {
         cy.get("input[id='courseLanguage']").should("have.value", course.courseLanguage);
         cy.get("input[id='ects']").should("have.value", course.ects);
         cy.get("textarea[id='courseDescription']").should("have.value", course.courseDescription);
+        cy.get("input[id='selectModule']").click();
+        for (let m of course.moduleIds) {
+            cy.get("div").contains(m).should("exist");
+        }
     });
 
     it("Select a module and join the course", () => {

--- a/tests/e2e/courseAdmission.spec.ts
+++ b/tests/e2e/courseAdmission.spec.ts
@@ -148,6 +148,7 @@ describe("Course Admission", () => {
 
     it("Select a module and join the course", () => {
         cy.get("input[id='selectModule']").clear().type(course.moduleIds[0]);
+        cy.get("div[id='selectModule_options']").click();
         cy.get("button[id='joinCourse']").click();
     });
 

--- a/tests/e2e/helpers/AuthHelper.ts
+++ b/tests/e2e/helpers/AuthHelper.ts
@@ -41,7 +41,7 @@ export function logout() {
     cy.get("div[id='menu_profile']").trigger("mouseover");
     cy.get("div[id='menu_profile']").children().eq(1).get("span").contains("Sign out").should("be.visible");
     cy.get("#nav_desktop_logout").click();
-    cy.url().should("eq", `${Cypress.config().baseUrl}/login`);
+    cy.url().should("eq", `${Cypress.config().baseUrl}login`);
 }
 
 export function logoutMobile() {
@@ -49,5 +49,5 @@ export function logoutMobile() {
     cy.get("nav").should("be.visible");
     cy.get("div[id='nav_mobile_menu_profile mobile-navbar-menu']").click();
     cy.get("#nav_mobile_logout").click();
-    cy.url().should("eq", Cypress.config().baseUrl);
+    cy.url().should("eq", `${Cypress.config().baseUrl}login`);
 }


### PR DESCRIPTION
# Description

- Fixes #794 

## Reason for this PR
- see #794

## Changes in this PR
- add an API call for fetching modules via the moduleIds given in the course object and construct the display string for the search-select component with id and name of the fetched modules

## Type of change (remove all that don't apply)
- Refactoring
- New feature (non-breaking change which adds functionality)
- 
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows 
- Browser: Firefox

- Frontend: (remove all that don't apply)
  - [x] Development build

- Backend: (remove all that don't apply)
  - [x] deployed development build

# Checklist: (remove all that don't apply)

- [x] I adapted corresponding E2E tests (especially for bugfixes)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)

# Screenshot:
![grafik](https://user-images.githubusercontent.com/63233799/104903795-c2928400-5980-11eb-98b0-1d6cef55d6a2.png)
