### PR TITLE
Release/v0.16.0 on Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-# [0.15.2 WIP](https://github.com/upb-uc4/ui-web/compare/v0.15.1...v0.15.2) (2021-01-XX)
+# [0.16.0](https://github.com/upb-uc4/ui-web/compare/v0.15.1...v0.16.0) (2021-01-18)
 ## Feature
 - add a simple data protection agreement page with a placeholder text referring to the university [#792](https://github.com/upb-uc4/ui-web/pull/792)
 
 ## Bugfix
 - fix bug where proto for decoding could not be found [793](https://github.com/upb-uc4/ui-web/pull/793)
+
 # [0.15.1](https://github.com/upb-uc4/ui-web/compare/v0.15.0...v0.15.1) (2021-01-07)
 ## Feature
 - add frontend validation using backend regex [#755](https://github.com/upb-uc4/ui-web/pull/755)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ui-web",
-    "version": "0.15.1",
+    "version": "0.16.0",
     "private": true,
     "scripts": {
         "serve": "vue-cli-service serve",


### PR DESCRIPTION
Remove this, if this PR is not to main!

<b>Version to release: v0.16.0</b>

## Merging this pull request will automatically:
- create a tag using the version in our package.json
- publish a release using this tag, referencing the CHANGELOG.md cy.get("input[id='selectModule']")
- publish the release on dockerhub using the version of our package.json

## Please fill out the following checklist:
- [x] The version of the package.json is different to every other tag in this repository
- [x] The CHANGELOG.md contains all changes (bugfixes, features, dependency updates, ...) for this release
