### PR TITLE
Add CSS Purge Safelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# [0.17.1-hotfix.1](https://github.com/upb-uc4/ui-web/compare/v0.17...v0.17.1) (2021-02-03)
+# [0.17.1-hotfix.1](https://github.com/upb-uc4/ui-web/compare/v0.17.1...v0.17.1-hotfix.1) (2021-02-03)
 ## Bugfix
 - Fix purgecss removing our fancy dark mode background. #828 [#829](https://github.com/upb-uc4/ui-web/pull/829)
   
-# [0.17.1](https://github.com/upb-uc4/ui-web/compare/v0.17...v0.17.1) (2021-02-02)
+# [0.17.1](https://github.com/upb-uc4/ui-web/compare/v0.17.0...v0.17.1) (2021-02-02)
+## Feature
 - Redesign the UI and upgrade to Tailwind 2. Add dark mode. [#782](https://github.com/upb-uc4/ui-web/pull/782)
 
 # [0.17.0](https://github.com/upb-uc4/ui-web/compare/v0.16.1-hotfix.1...v0.17.0) (2021-29-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# [0.17.1](https://github.com/upb-uc4/ui-web/compare/v0.17...v0.17.1) (2021-01-02)
+# [0.17.1-hotfix.1](https://github.com/upb-uc4/ui-web/compare/v0.17...v0.17.1) (2021-02-03)
+## Bugfix
+- Fix purgecss removing our fancy dark mode background. #828 [#829](https://github.com/upb-uc4/ui-web/pull/829)
+  
+# [0.17.1](https://github.com/upb-uc4/ui-web/compare/v0.17...v0.17.1) (2021-02-02)
 - Redesign the UI and upgrade to Tailwind 2. Add dark mode. [#782](https://github.com/upb-uc4/ui-web/pull/782)
 
 # [0.17.0](https://github.com/upb-uc4/ui-web/compare/v0.16.1-hotfix.1...v0.17.0) (2021-29-01)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ui-web",
-    "version": "0.17.1",
+    "version": "0.17.1-hotfix.1",
     "private": true,
     "scripts": {
         "serve": "vue-cli-service serve",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,14 @@
 const colors = require("tailwindcss/colors");
 
 module.exports = {
-    purge: ["./src/**/*.html", "./src/**/*.vue"],
+    purge: {
+        enabled: true,
+        preserveHtmlElements: false,
+        content: ["./src/**/*.html", "./src/**/*.vue"],
+        options: {
+            safelist: ["bg-night-black"],
+        },
+    },
     darkMode: "class",
     theme: {
         colors: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
         preserveHtmlElements: false,
         content: ["./src/**/*.html", "./src/**/*.vue"],
         options: {
-            safelist: ["bg-night-black"],
+            safelist: [/dark/],
         },
     },
     darkMode: "class",


### PR DESCRIPTION
# Description

- Fixes #828

## Reason for this PR
- The class for the dark-mode background colour was missing in the purged css file.

## Changes in this PR
- Add whitelist of css classes to spare during purge.


## Type of change
- Hotfix

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)