### PR TITLE
reset year when semester type is changed. also removed unused functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [WIP 0.18.1](https://github.com/upb-uc4/ui-web/compare/v0.18.0...v0.18.1) (2021-XX-XX)
 ## Bugfix
 - fix profile picture in navbar not updating properly[#855](https://github.com/upb-uc4/ui-web/pull/855)
+- fix a bug that the year selection would not reset properly[#827](https://github.com/upb-uc4/ui-web/pull/827)
 
 ## Refactor
 - use consistent timeformat for localeDate strings [#799](https://github.com/upb-uc4/ui-web/pull/799)

--- a/src/views/student/Immatriculation.vue
+++ b/src/views/student/Immatriculation.vue
@@ -63,7 +63,7 @@
 </template>
 
 <script lang="ts">
-    import { computed, onBeforeMount, ref } from "vue";
+    import { computed, onBeforeMount, ref, watch } from "vue";
     import SubjectMatriculation from "@/api/api_models/matriculation_management/SubjectMatriculation";
     import GenericResponseHandler from "@/use/helpers/GenericResponseHandler";
     import LoadingSpinner from "@/components/common/loading/Spinner.vue";
@@ -170,10 +170,6 @@
                 year.value = "";
             }
 
-            function updateSelectedFieldsOfStudy(value: any) {
-                selectedFieldsOfStudy.value = value.value;
-            }
-
             async function updateImmatriculation() {
                 isLoading.value = true;
                 const matriculationEntries: SubjectMatriculation[] = [];
@@ -205,18 +201,21 @@
                 selectedFieldsOfStudy.value.push(field.value as string);
             }
 
+            watch(semesterType, (currentSemesterType) => {
+                //reset the year because the year selection is different per semester type (SS -> YYYY vs. WS -> YYYY/YYYY)
+                year.value = "";
+            });
+
             return {
                 addFieldOfStudy,
                 removeFieldOfStudy,
                 availableFieldsOfStudy,
                 isLoading,
-                resetYear,
                 fieldsOfStudy,
                 selectableYears,
                 year,
                 semesterType,
                 selectedFieldsOfStudy,
-                updateSelectedFieldsOfStudy,
                 updateImmatriculation,
                 validSelection,
                 errorBag,


### PR DESCRIPTION
# Description

- Fixes #827

## Reason for this PR
- summer and winter semester have different year notations (YYYY vs YYYY/YYYY).

## Changes in this PR
- changing the semester type resets the year dropdown so it has to be selected manually.

## Type of change
- Bug fix

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows Mac Linux
- Browser: Firefox Chrome Safari Chromium

- Frontend:
  - [x] Development build
  
- Backend: 
  - [x] No backend needed to test this

# Checklist: 

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)