### PR TITLE
fix typo preventing courses from updating modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bugfix
 - fix colour of uc4 logo in mobile navigation [#834](https://github.com/upb-uc4/ui-web/pull/834)
+- fix bug prventing modules from being updated correctly in courses [#839](https://github.com/upb-uc4/ui-web/pull/839)
 
 # [0.17.1-hotfix.2](https://github.com/upb-uc4/ui-web/compare/v0.17.1-hotfix.1...v0.17.1-hotfix.2) (2021-02-03)
 ## Bugfix

--- a/src/views/shared/EditCreateCourseForm.vue
+++ b/src/views/shared/EditCreateCourseForm.vue
@@ -16,7 +16,7 @@
                 :module-ids="course.moduleIds"
                 :error-bag="errorBag"
                 :edit-mode="editMode"
-                @update-modules-ids="updateModuleIds"
+                @update-module-ids="updateModuleIds"
             />
             <restrictions-section v-model:maxParticipants="course.maxParticipants" :error-bag="errorBag" />
             <time-section v-model:start="course.startDate" v-model:end="course.endDate" :error-bag="errorBag" />


### PR DESCRIPTION
# Description

- Fixes #838 

## Reason for this PR
- modules were not set correctly in courses

## Changes in this PR
- fixing a typo that prevented courses from updating Modules when they were edited during editing or creating of the course (event mismatch).

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows
- Browser: Firefox

- Frontend: 
  - [X] Development build

- Backend: 
  - [X] deployed development build

# Checklist: 

- [X] I have performed a self-review of my own code
- [X] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)