### PR TITLE
Refactor modal component widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ## Bugfix
 - fix colour of uc4 logo in mobile navigation [#834](https://github.com/upb-uc4/ui-web/pull/834)
 
+## Refactor 
+- fix centering of modal components [#849](https://github.com/upb-uc4/ui-web/pull/849)
+
 # [0.17.1-hotfix.2](https://github.com/upb-uc4/ui-web/compare/v0.17.1-hotfix.1...v0.17.1-hotfix.2) (2021-02-03)
 ## Bugfix
 - Fix a bug that broke matriculation

--- a/src/components/modals/DecryptPrivateKeyModal.vue
+++ b/src/components/modals/DecryptPrivateKeyModal.vue
@@ -3,7 +3,7 @@
         <template #header>
             <p class="modal-headline">Confirmation Needed</p>
         </template>
-        <div>
+        <div class="w-full">
             <p class="modal-description">
                 Please enter the password you used to encrypt your private key. This may differ from your regular application password.
             </p>

--- a/src/components/modals/DeleteAccountModal.vue
+++ b/src/components/modals/DeleteAccountModal.vue
@@ -3,7 +3,7 @@
         <template #header>
             <p class="modal-headline">Delete account</p>
         </template>
-        <div class="modal-description">
+        <div class="modal-description w-full">
             Are you sure you want to delete this account?<br />
             By doing this you will lose all of your saved data and will not be able to restore it.
         </div>

--- a/src/components/modals/DeleteCourseModal.vue
+++ b/src/components/modals/DeleteCourseModal.vue
@@ -4,7 +4,7 @@
             <p class="modal-headline">Delete course</p>
         </template>
 
-        <div class="modal-description">
+        <div class="modal-description w-full">
             Are you sure you want to delete this course?<br />
             By doing this you will lose all of your saved data and will not be able to restore it.
         </div>

--- a/src/components/modals/DeleteOwnAccountModal.vue
+++ b/src/components/modals/DeleteOwnAccountModal.vue
@@ -6,7 +6,7 @@
         <div v-if="busy" class="mx-auto">
             <loading-spinner />
         </div>
-        <div v-else class="flex flex-col">
+        <div v-else class="flex flex-col w-full">
             <div class="my-2 w-full flex justify-center my-8">
                 <div class="fa-stack fa-2x">
                     <i class="fas fa-circle fa-stack-2x text-red-200" />

--- a/src/components/modals/DeleteProfilePictureModal.vue
+++ b/src/components/modals/DeleteProfilePictureModal.vue
@@ -3,7 +3,7 @@
         <template #header>
             <p class="modal-headline mb-2">Delete Profile Picture</p>
         </template>
-        <div class="modal-description">Are you sure you want to delete the profile picture? You won't be able to restore it.</div>
+        <div class="modal-description w-full">Are you sure you want to delete the profile picture? You won't be able to restore it.</div>
         <template #footer>
             <button id="deleteProfilePictureModalCancel" class="mr-10 btn-tertiary-modal" @click="close(action.CANCEL)">Cancel</button>
             <button id="deleteProfilePictureModalDelete" class="w-24 py-2 px-2 btn btn-remove" @click="close(action.DELETE)">Delete</button>

--- a/src/components/modals/EncryptPrivateKeyModal.vue
+++ b/src/components/modals/EncryptPrivateKeyModal.vue
@@ -3,7 +3,7 @@
         <template #header>
             <p class="modal-headline">Choose Encryption Password</p>
         </template>
-        <div>
+        <div class="w-full">
             <div class="modal-description">
                 Please choose a password to encrypt your private key, so it can be securely stored on our servers. Ensure that you do not
                 lose this password as it <span class="text-blue-800 font-medium">cannot be restored</span>.

--- a/src/components/modals/LoginModal.vue
+++ b/src/components/modals/LoginModal.vue
@@ -7,7 +7,7 @@
             <div class="modal-description">Please enter your authentication credentials.</div>
 
             <div class="my-4">
-                <label class="input-label">Email Address</label>
+                <label class="input-label">Username</label>
                 <input
                     id="loginModalEmail"
                     v-model="email"

--- a/src/components/modals/LoginModal.vue
+++ b/src/components/modals/LoginModal.vue
@@ -3,7 +3,7 @@
         <template #header>
             <p class="modal-headline">Login</p>
         </template>
-        <div class="flex flex-col">
+        <div class="flex flex-col w-full">
             <div class="modal-description">Please enter your authentication credentials.</div>
 
             <div class="my-4">

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -24,7 +24,7 @@
                                 </svg>
                             </button>
                         </div>
-                        <div class="flex mt-4 mr-8 text-lg text-gray-600 leading-relaxed tracking-wide">
+                        <div class="flex mt-4 text-lg text-gray-600 leading-relaxed tracking-wide">
                             <slot></slot>
                         </div>
                     </div>

--- a/src/components/modals/ModalNoTeleport.vue
+++ b/src/components/modals/ModalNoTeleport.vue
@@ -23,7 +23,7 @@
                             </svg>
                         </button>
                     </div>
-                    <div class="flex mt-4 mr-8">
+                    <div class="flex mt-4">
                         <slot></slot>
                     </div>
                 </div>

--- a/src/components/modals/UnsavedChangesModal.vue
+++ b/src/components/modals/UnsavedChangesModal.vue
@@ -3,7 +3,7 @@
         <template #header>
             <p class="modal-headline">Unsaved Changes</p>
         </template>
-        <div class="modal-description">Do you really want to continue and leave this page? You have unsaved changes.</div>
+        <div class="modal-description w-full">Do you really want to continue and leave this page? You have unsaved changes.</div>
         <template #footer>
             <button id="unsavedChangesModalCancel" class="mr-10 btn-tertiary-modal" @click="close(action.CANCEL)">Cancel</button>
             <button id="unsavedChangesModalConfirmLeave" class="w-24 py-2 px-2 btn" @click="close(action.CONFIRM)">Leave</button>


### PR DESCRIPTION
# Description

Centering in modals was off.
Before:
![grafik](https://user-images.githubusercontent.com/63233799/107521743-36f0c980-6bb3-11eb-870b-03865d7c76aa.png)

After:
![grafik](https://user-images.githubusercontent.com/63233799/107521805-46701280-6bb3-11eb-8866-89b951476908.png)


## Changes in this PR
- Remove margin-right-8 in base modals
- Add "w-full" to components within the modal slots

## Type of change (remove all that don't apply)
- Refactoring


# Checklist: (remove all that don't apply)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)