### PR TITLE
Bugfix: Update Navbar on Profile Pic Deletion

### DIFF
--- a/src/components/profile/ProfilePictureSection.vue
+++ b/src/components/profile/ProfilePictureSection.vue
@@ -192,7 +192,6 @@
                         }
                         case action.DELETE: {
                             deletePicture();
-                            store.commit(MutationTypes.FORCE_UPDATE_PROFILE_PICTURE);
                             break;
                         }
                     }
@@ -208,6 +207,7 @@
                 const result = await handler.handleResponse(response);
                 if (result) {
                     await getProfilePicture();
+                    store.commit(MutationTypes.FORCE_UPDATE_PROFILE_PICTURE);
                 }
                 isLoading.value = false;
             }


### PR DESCRIPTION
# Description

- Fixes updating the profile picture in the navbar

## Reason for this PR
- The update via the store was forced before the async deleteProfilePicture function was finished

## Changes in this PR
- Force Profile Picture update on Navbar when deletion was sucessfull

### Dependency update
- List all new dependencies (delete if no additions)

## Type of change (remove all that don't apply)
- Bug fix (non-breaking change which fixes an issue)
- 
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

**Test Configuration**:
- OS: Windows Mac Linux
- Browser: Firefox Chrome Safari Chromium

- Frontend: (remove all that don't apply)
  - [x] Development build
- Backend: (remove all that don't apply)
  - [x] deployed development build

# Checklist: (remove all that don't apply)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [ ] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)

## Note:
I think #820 was already fixed. Hence:
Closes #820 