### PR TITLE
Bugfix exam form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-# [0.19.2](https://github.com/upb-uc4/ui-web/compare/v0.19.1...v0.19.2) (2021-03-XX)+
+# [0.19.2 WIP](https://github.com/upb-uc4/ui-web/compare/v0.19.1...v0.19.2) (2021-03-XX)
+## Feature
 - Add option to cancel own pending operations [#881](https://github.com/upb-uc4/ui-web/pull/881)
+
+## Bugfix
+- fix multiple bugs with exams [#878](https://github.com/upb-uc4/ui-web/pull/878)
 
 # [0.19.1](https://github.com/upb-uc4/ui-web/compare/v0.19.0...v0.19.1) (2021-03-03)
 ## Feature

--- a/src/components/common/DatePicker.vue
+++ b/src/components/common/DatePicker.vue
@@ -60,7 +60,7 @@
             if (props.date) {
                 let dates = props.date.split("-");
                 let date = new Date(+dates[0], dates[1] - 1, +dates[2]);
-                selectedDay.value = date.getDay().toString();
+                selectedDay.value = date.getDate().toString();
                 selectedMonth.value = date.toLocaleString("en-GB", { month: "long" });
                 selectedYear.value = date.getFullYear().toString();
             }

--- a/src/components/common/ISODatePicker.vue
+++ b/src/components/common/ISODatePicker.vue
@@ -52,8 +52,8 @@
 
             if (props.isoDate) {
                 const dateObject = new Date(myIsoDate.value);
-                const paddedMonth = numberZeroPad(dateObject.getMonth());
-                const paddedDay = numberZeroPad(dateObject.getDay());
+                const paddedMonth = numberZeroPad(dateObject.getMonth() + 1);
+                const paddedDay = numberZeroPad(dateObject.getDate());
                 myDate.value = `${dateObject.getFullYear()}-${paddedMonth}-${paddedDay}`;
                 const paddedHours = numberZeroPad(dateObject.getHours());
                 const paddedMinutes = numberZeroPad(dateObject.getMinutes());

--- a/src/components/exam/edit/BasicsSection.vue
+++ b/src/components/exam/edit/BasicsSection.vue
@@ -53,7 +53,6 @@
     import Select from "@/components/common/Select.vue";
     import { useModelWrapper } from "@/use/helpers/ModelWrapper";
     import ISODatePicker from "@/components/common/ISODatePicker.vue";
-    import { dateFormatOptions } from "@/use/helpers/DateFormatOptions";
 
     export default {
         name: "CourseModuleSection",
@@ -97,7 +96,7 @@
         setup(props: any, { emit }: any) {
             const isLoading = ref(false);
             const selectedCourse = ref();
-            const selectedModule = ref(props.moduleId);
+            const selectedModule = ref("");
             const myEcts = ref(props.ects);
             const availableModules = ref([] as String[]);
 
@@ -107,8 +106,10 @@
 
             onBeforeMount(async () => {
                 isLoading.value = true;
-                if (props.viewMode) {
-                    selectedCourse.value = getCourse();
+                selectedCourse.value = getCourse();
+                if (selectedCourse.value) {
+                    availableModules.value = (selectedCourse.value as Course)?.moduleIds;
+                    selectedModule.value = props.moduleId;
                 }
                 isLoading.value = false;
             });

--- a/src/components/exam/list/ExamList.vue
+++ b/src/components/exam/list/ExamList.vue
@@ -120,16 +120,17 @@
                     if (result) tmpCourses.unshift(result);
                 }
                 courses.value = tmpCourses;
-
-                const genericResponseHandler = new GenericResponseHandler("exams");
-                const exam_management = new ExamManagement();
-                const examResponse = await exam_management.getExams(
-                    undefined,
-                    courses.value.map((course) => course.courseId),
-                    undefined,
-                    result.map((r) => r.moduleId)
-                );
-                exams.value = genericResponseHandler.handleResponse(examResponse);
+                if (courses.value.length > 0) {
+                    const genericResponseHandler = new GenericResponseHandler("exams");
+                    const exam_management = new ExamManagement();
+                    const examResponse = await exam_management.getExams(
+                        undefined,
+                        courses.value.map((course) => course.courseId),
+                        undefined,
+                        result.map((r) => r.moduleId)
+                    );
+                    exams.value = genericResponseHandler.handleResponse(examResponse);
+                }
             }
 
             async function getOwnEnrollmentId(): Promise<string> {

--- a/src/views/shared/CreateViewExamForm.vue
+++ b/src/views/shared/CreateViewExamForm.vue
@@ -42,7 +42,7 @@
 
 <script lang="ts">
     import Router from "@/use/router/";
-    import { computed, onBeforeMount, ref } from "vue";
+    import { computed, onBeforeMount, ref, watch } from "vue";
     import ErrorBag from "@/use/helpers/ErrorBag";
     import UnsavedChangesModal from "@/components/modals/UnsavedChangesModal.vue";
     import { onBeforeRouteLeave } from "vue-router";
@@ -90,7 +90,7 @@
             let isLoading = ref(false);
             let exam = ref(new ExamEntity());
             let initialExamState = ref(new ExamEntity());
-            let heading = props.createMode ? "Create Exam" : "Exam";
+            let heading = ref(props.viewMode ? "Exam" : "Create Exam");
             let success = ref(false);
             let unsavedChangesModal = ref();
 
@@ -135,6 +135,19 @@
                 await getMyCourses();
                 isLoading.value = false;
             });
+
+            watch(
+                () => props.viewMode,
+                () => {
+                    heading.value = props.viewMode ? "Exam" : "Create Exam";
+                    if (!props.viewMode) {
+                        isLoading.value = true;
+                        exam.value = new ExamEntity();
+                        initialExamState.value = new ExamEntity();
+                        isLoading.value = false;
+                    }
+                }
+            );
 
             const isLecturer = computed(() => {
                 return role.value === Role.LECTURER;


### PR DESCRIPTION
## Reason for this PR
- Date object was parsed in a wrong way
- resetting course and module did not work on failure
- exam list crashed when student fetched exams but no matching courses

## Changes in this PR
- fix parsing of object
- watching the `viewMode` prop to react on page navigation 
- setting course and module explicitly in basics-section
- only fetch exams if the courses were found

## Type of change (remove all that don't apply)
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

# Checklist: (remove all that don't apply)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [x] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)