### PR TITLE
Cancel own pending operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [0.19.2](https://github.com/upb-uc4/ui-web/compare/v0.19.1...v0.19.2) (2021-03-XX)+
+- Add option to cancel own pending operations [#881](https://github.com/upb-uc4/ui-web/pull/881)
+
 # [0.19.1](https://github.com/upb-uc4/ui-web/compare/v0.19.0...v0.19.1) (2021-03-03)
 ## Feature
 - Add exams API [#864](https://github.com/upb-uc4/ui-web/pull/864)

--- a/src/components/common/dashboard/OperationComponent.vue
+++ b/src/components/common/dashboard/OperationComponent.vue
@@ -324,12 +324,12 @@
                 provideReason.value = !provideReason.value;
             }
 
-            async function reject(abortOwn?: boolean) {
-                const reason = abortOwn ? "Abort" : finalReason.value;
+            async function reject(isCancellation?: boolean) {
+                const reason = isCancellation ? "Abort" : finalReason.value;
                 if (await executeTransaction(new RejectOperationTransaction(operation.value, reason))) {
                     store.commit(MutationTypes.ADD_OPERATION_REJECTION, operation.value.operationId);
                     sentReject.value = true;
-                    if (!abortOwn) {
+                    if (!isCancellation) {
                         provideReason.value = !provideReason.value;
                     }
                     toggleDetails();

--- a/src/components/common/dashboard/OperationComponent.vue
+++ b/src/components/common/dashboard/OperationComponent.vue
@@ -78,27 +78,41 @@
                         </div>
                     </div>
                 </div>
-                <div v-if="actionRequired && isPending" class="w-full md:w-1/3 flex justify-end items-baseline">
-                    <button
-                        :id="'op_approve_' + shownOpId"
-                        :disabled="sentApprove"
-                        :class="{ invisible: sentReject }"
-                        class="w-8 h-8 btn-base btn-icon-green text-xs"
-                        title="Approve"
-                        @click.stop="approve"
-                    >
-                        <i class="fas fa-check"></i>
-                    </button>
-                    <button
-                        :id="'op_startRejection_' + shownOpId"
-                        :disabled="sentReject || provideReason"
-                        :class="{ invisible: sentApprove }"
-                        class="ml-2 w-8 h-8 btn-base btn-icon-red-filled text-xs"
-                        title="Reject"
-                        @click.stop="toggleReasonMenu"
-                    >
-                        <i class="fas fa-times"></i>
-                    </button>
+                <div v-if="isPending" class="w-full md:w-1/3 flex justify-end items-baseline">
+                    <div v-if="actionRequired">
+                        <button
+                            :id="'op_approve_' + shownOpId"
+                            :disabled="sentApprove"
+                            :class="{ invisible: sentReject }"
+                            class="w-8 h-8 btn-base btn-icon-green text-xs"
+                            title="Approve"
+                            @click.stop="approve"
+                        >
+                            <i class="fas fa-check"></i>
+                        </button>
+                        <button
+                            :id="'op_startRejection_' + shownOpId"
+                            :disabled="sentReject || provideReason"
+                            :class="{ invisible: sentApprove }"
+                            class="ml-2 w-8 h-8 btn-base btn-icon-red-filled text-xs"
+                            title="Reject"
+                            @click.stop="toggleReasonMenu"
+                        >
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
+                    <div v-else-if="isMyOperation">
+                        <button
+                            :id="'op_cancel_' + shownOpId"
+                            :disabled="sentReject || provideReason"
+                            :class="{ invisible: sentApprove }"
+                            class="ml-2 w-8 h-8 btn-base btn-icon-red-filled text-xs"
+                            title="Abort this operation"
+                            @click.stop="abortOperation"
+                        >
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
                 </div>
             </div>
             <div v-if="showDetails" class="flex flex-col w-full mt-4 dark:text-gray-400">
@@ -362,6 +376,10 @@
                 params.value = await printOperation(operation.value);
             }
 
+            async function abortOperation() {
+                //TODO
+            }
+
             return {
                 statusColor,
                 type,
@@ -395,6 +413,7 @@
                 title,
                 shownOpId,
                 loading,
+                abortOperation,
             };
         },
     };

--- a/src/components/common/dashboard/OperationComponent.vue
+++ b/src/components/common/dashboard/OperationComponent.vue
@@ -104,11 +104,11 @@
                     <div v-else-if="isMyOperation">
                         <button
                             :id="'op_cancel_' + shownOpId"
-                            :disabled="sentReject || provideReason"
+                            :disabled="sentReject"
                             :class="{ invisible: sentApprove }"
                             class="ml-2 w-8 h-8 btn-base btn-icon-red-filled text-xs"
                             title="Abort this operation"
-                            @click.stop="abortOperation"
+                            @click.stop="reject(true)"
                         >
                             <i class="fas fa-times"></i>
                         </button>
@@ -151,7 +151,7 @@
                             :title="finalReason == '' ? 'Please provide a reason' : 'Reject'"
                             :disabled="finalReason == ''"
                             class="btn btn-remove text-sm h-12"
-                            @click.stop="reject"
+                            @click.stop="reject()"
                         >
                             Reject
                         </button>
@@ -324,11 +324,14 @@
                 provideReason.value = !provideReason.value;
             }
 
-            async function reject() {
-                if (await executeTransaction(new RejectOperationTransaction(operation.value, finalReason.value))) {
+            async function reject(abortOwn?: boolean) {
+                const reason = abortOwn ? "Abort" : finalReason.value;
+                if (await executeTransaction(new RejectOperationTransaction(operation.value, reason))) {
                     store.commit(MutationTypes.ADD_OPERATION_REJECTION, operation.value.operationId);
                     sentReject.value = true;
-                    provideReason.value = !provideReason.value;
+                    if (!abortOwn) {
+                        provideReason.value = !provideReason.value;
+                    }
                     toggleDetails();
                 }
             }
@@ -376,10 +379,6 @@
                 params.value = await printOperation(operation.value);
             }
 
-            async function abortOperation() {
-                //TODO
-            }
-
             return {
                 statusColor,
                 type,
@@ -413,7 +412,6 @@
                 title,
                 shownOpId,
                 loading,
-                abortOperation,
             };
         },
     };

--- a/src/components/common/dashboard/OperationComponent.vue
+++ b/src/components/common/dashboard/OperationComponent.vue
@@ -325,7 +325,7 @@
             }
 
             async function reject(isCancellation?: boolean) {
-                const reason = isCancellation ? "Abort" : finalReason.value;
+                const reason = isCancellation ? "Operation aborted by initiator." : finalReason.value;
                 if (await executeTransaction(new RejectOperationTransaction(operation.value, reason))) {
                     store.commit(MutationTypes.ADD_OPERATION_REJECTION, operation.value.operationId);
                     sentReject.value = true;


### PR DESCRIPTION
# Description
Add option to cancel pending own operations

## Changes in this PR
- show cancel button for pending selfinitiated operations
- link button to reject function (reject with reason "Abort" in this case)


## Type of change (remove all that don't apply)
- New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested all use cases this could alter

# Checklist: (remove all that don't apply)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new linting warnings or console warnings
- [ ] I have updated the CHANGELOG.md to include any changes made in this PR (add WIP to the top, if there is none already)